### PR TITLE
v1.2: twice-daily cadence on Asia/Taipei

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # ME War Intel Brief
 
-A daily public intelligence brief on the 2026 US-Israeli war on Iran (Operation
-Epic Fury), researched and written autonomously each day by a Claude Code
-Routine and published to a Next.js site on Vercel. Git is the audit trail.
-Produced by 3D ([@8gara8](https://x.com/8gara8)).
+A public intelligence brief on the 2026 US-Israeli war on Iran (Operation
+Epic Fury), researched and written autonomously **twice daily** by two Claude
+Code Routines — a morning full brief at 09:00 Asia/Taipei (01:00 UTC) and an
+evening flash at 18:00 Asia/Taipei (10:00 UTC) — and published to a Next.js
+site on Vercel. Git is the audit trail. Produced by 3D
+([@8gara8](https://x.com/8gara8)).
 
 **Live URL:** _to be filled in once Vercel is linked._
 
@@ -11,11 +13,20 @@ Produced by 3D ([@8gara8](https://x.com/8gara8)).
 
 Three parts in a loop:
 
-1. **Producer** — a [Claude Code Routine](https://claude.ai/code/scheduled) that
-   runs on Anthropic cloud infrastructure once per day, performs the research,
-   writes the brief MDX, updates `content/context.md`, and commits to `main`.
+1. **Producers** — two [Claude Code Routines](https://claude.ai/code/scheduled)
+   that run on Anthropic cloud infrastructure:
+   - **Morning Routine** (09:00 Asia/Taipei / 01:00 UTC): does the research,
+     writes the full brief MDX + sidecar `.data.ts`, rewrites
+     `content/context.md`, and commits to `main`. Driven by
+     `routine/PROMPT_morning.md`.
+   - **Evening flash Routine** (18:00 Asia/Taipei / 10:00 UTC): does targeted
+     research on the ~9-hour window since the morning run and appends a short
+     time-stamped note to the `## Evening flash notes` section of
+     `content/context.md`. Driven by `routine/PROMPT_flash.md`. Under the v2
+     light-touch scope, flashes do **not** write new `.mdx` files; they are
+     folded into the next morning's full brief.
 2. **Store** — this repository. The brief archive lives in `content/briefs/`,
-   one MDX file per day.
+   one MDX file per day; flash notes live in `content/context.md`.
 3. **Presenter** — a Next.js 15 (App Router) site deployed on Vercel, rebuilt
    on every push.
 
@@ -25,9 +36,11 @@ full design rationale, and `SPEC.md` for the canonical build spec.
 ## Repo layout (highlights)
 
 ```
-content/briefs/       Daily brief MDX files. The routine writes here.
-content/context.md    Rolling analytical context. Rewritten in full each run.
-routine/              PROMPT.md, INSTRUCTIONS.md, JSON schemas, few-shot examples.
+content/briefs/       Daily brief MDX files. The morning routine writes here.
+content/context.md    Rolling analytical context. Morning routine rewrites in full;
+                      evening flash routine appends to the flash-notes section only.
+routine/              PROMPT_morning.md, PROMPT_flash.md, INSTRUCTIONS.md,
+                      JSON schemas, few-shot examples.
 app/                  Next.js App Router pages.
 components/           MDX + layout + chart components.
 lib/                  Brief loader, build-time data aggregation, types, MDX config.
@@ -70,17 +83,31 @@ Vercel's default build command regenerates data transparently.
 
 ## Routine setup (one-time, by analyst)
 
-After the repo is public and authorized for Claude Code access:
+After the repo is public and authorized for Claude Code access, configure
+**two** Routines at [claude.ai/code/scheduled](https://claude.ai/code/scheduled),
+both pointing at this repo, branch `main`:
 
-1. Go to [claude.ai/code/scheduled](https://claude.ai/code/scheduled).
-2. Create a new routine pointing at this repo, branch `main`.
-3. For the run-time prompt, point the routine at `routine/PROMPT.md` (or paste
-   its contents directly into the prompt field).
-4. Schedule the routine for your preferred daily run time (recommend the same
-   hour daily, evening UTC).
-5. Trigger a first manual run to validate the pipeline end-to-end. Expected
-   outputs: a new MDX file in `content/briefs/`, a rewritten `content/context.md`,
-   and a commit/push to `main` with message `Day NNN brief — YYYY-MM-DD`.
+1. **Morning full-brief Routine.**
+   - Prompt: paste the contents of `routine/PROMPT_morning.md` into the
+     run-time prompt field (or point the routine at it).
+   - Schedule: **01:00 UTC daily** (= 09:00 Asia/Taipei).
+   - First-run expected output: a new MDX file in `content/briefs/` with its
+     sidecar `.data.ts`, a rewritten `content/context.md`, and a commit/push
+     to `main` with message `Day NNN brief — YYYY-MM-DD`.
+
+2. **Evening flash Routine.**
+   - Prompt: paste the contents of `routine/PROMPT_flash.md` into the run-time
+     prompt field.
+   - Schedule: **10:00 UTC daily** (= 18:00 Asia/Taipei).
+   - First-run expected output: the `## Evening flash notes` section of
+     `content/context.md` is populated with one time-stamped paragraph, and a
+     commit/push to `main` with message `Day NNN flash — YYYY-MM-DD` (or
+     `Day NNN flash (quiet) — YYYY-MM-DD` if there was no material change).
+   - The flash Routine does **not** write new brief files under the v2
+     light-touch scope; flashes are folded into the next morning's brief.
+
+Trigger a first manual run of each Routine to validate the pipeline
+end-to-end before relying on the schedules.
 
 ## Vercel setup (one-time, by analyst)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,17 +2,31 @@
 
 **For:** Claude Code
 **By:** 3D (@8gara8)
-**Date:** April 22, 2026
+**Date:** April 22, 2026 (v1.2 — twice-daily + Asia/Taipei)
 **Repo target:** `me-war-intel-brief` (public, owner `@8gara8` on GitHub)
-**Companion design doc:** `me-war-intel-brief DESIGN v1 1 2026-04-22.docx` at the repo root.
+**Companion design doc:** `ME_War_Intel_Brief_DESIGN_v1_2.docx` (committed to `docs/` by analyst). The earlier `me-war-intel-brief DESIGN v1 1 2026-04-22.docx` at the repo root remains in place as the design baseline.
+
+> **v1.2 changes from v1.1:** the routine cadence moves from once daily to
+> **twice daily**, both anchored to **Asia/Taipei** (analyst's timezone):
+> a morning full brief at 09:00 (01:00 UTC) and an evening flash at 18:00
+> (10:00 UTC). The v1.2 build is **light-touch**: the site, schemas, and
+> validator stay single-brief-per-day; flashes are captured as appended notes
+> to `content/context.md`'s `## Evening flash notes` section and folded into
+> the next morning's full brief by the morning Routine. A later build will
+> promote flashes to dedicated `.mdx` files with a flash page treatment.
 
 -----
 
 ## What you're building
 
-A **public daily intelligence website** that publishes one analytical brief per day on the 2026 US-Israeli war on Iran (Operation Epic Fury). The brief is researched and written autonomously by a Claude Code Routine running on Anthropic cloud infrastructure (`claude.ai/code/scheduled`). The site is Next.js on Vercel, statically rebuilt on every commit. The whole loop is **producer (routine) → store (this repo) → presenter (Vercel site)**, with git as the audit trail.
+A **public twice-daily intelligence site** that publishes analytical coverage of the 2026 US-Israeli war on Iran (Operation Epic Fury). Two Claude Code Routines run on Anthropic cloud infrastructure (`claude.ai/code/scheduled`):
 
-The analyst handles: (1) creating the empty GitHub repo, (2) authorizing Claude Code's GitHub access to it, (3) linking the repo to a new Vercel project, (4) configuring the routine at claude.ai/code/scheduled. Everything else is scaffolded by this repo.
+1. A **morning full-brief Routine** at 09:00 Asia/Taipei (01:00 UTC), which researches and writes the canonical daily brief.
+2. An **evening flash Routine** at 18:00 Asia/Taipei (10:00 UTC), which does targeted research on the ~9-hour window since the morning run and appends a time-stamped flash note to `content/context.md`.
+
+The site is Next.js on Vercel, statically rebuilt on every commit. The whole loop is **producers (two routines) → store (this repo) → presenter (Vercel site)**, with git as the audit trail.
+
+The analyst handles: (1) creating the empty GitHub repo, (2) authorizing Claude Code's GitHub access to it, (3) linking the repo to a new Vercel project, (4) configuring **both** routines at claude.ai/code/scheduled. Everything else is scaffolded by this repo.
 
 -----
 
@@ -168,25 +182,42 @@ One seed brief at `content/briefs/2026-02-28-day-001.mdx` covering Day 1 (war st
 
 ## 7. Seed `content/context.md`
 
-Fixed section structure (see `routine/schemas/context.schema.md`): Current war status, Cumulative state, Active deadlines, Diplomatic state, Standing analytical threads, What to watch tomorrow. The routine rewrites this file in full on every run.
+Fixed section structure (see `routine/schemas/context.schema.md`): Current war status, Cumulative state, Active deadlines, Diplomatic state, Standing analytical threads, What to watch tomorrow, **Evening flash notes**. The morning Routine rewrites this file in full on every run, resetting the Evening flash notes section to `(None yet for today.)`. The evening flash Routine only appends to that one section and leaves every other section untouched.
 
 -----
 
-## 8. `routine/PROMPT.md`
+## 8. Routine prompts
 
-Short run-time prompt that points at `INSTRUCTIONS.md` and lays out the hard rules:
+Two prompt files drive the two cadences.
+
+### 8.1 `routine/PROMPT_morning.md`
+
+Run-time prompt for the 09:00 Asia/Taipei (01:00 UTC) morning Routine. Points at `INSTRUCTIONS.md` and lays out the hard rules for writing the canonical full brief:
 
 - No partial commits.
 - No silently fabricated data.
-- Cite every source.
+- Cite every source (minimum 8 unless `quiet_day: true`).
 - Don't touch `data/`.
 - Don't edit `app/`, `components/`, `lib/`, or `routine/` unless tasked with a structural change.
+- On rewrite, reset `content/context.md`'s `## Evening flash notes` section to `(None yet for today.)` — yesterday's flash notes are incorporated into today's brief body (per step 2 of the morning prompt) and should not persist.
+
+### 8.2 `routine/PROMPT_flash.md`
+
+Run-time prompt for the 18:00 Asia/Taipei (10:00 UTC) evening flash Routine. This is a **lightweight delta**, not a re-research:
+
+- Read today's morning brief to establish the baseline; do not re-cover it.
+- Research only the ~9-hour window since the morning run.
+- Write one time-stamped paragraph to `content/context.md`'s `## Evening flash notes` section — either a material-change flash (3–6 sentences, min 3 sources) or a no-material-change flash (1–3 sentences, no source floor).
+- **Do not create a new `.mdx` file.** Under v1.2 light-touch scope, the repo's brief schema and validator remain single-brief-per-day. The only writable surface is the flash-notes section of `content/context.md`.
+- Never touch any other section of `content/context.md`.
+- Never change casualty numbers or clock states anywhere.
+- If the morning Routine failed and no morning brief exists for today, the evening Routine is **promoted** to writing a full brief per `PROMPT_morning.md` with `gap_acknowledged: true`.
 
 -----
 
 ## 9. `routine/INSTRUCTIONS.md`
 
-The editorial brain: research conventions, multi-clock framework, editorial style, standing analytical threads, per-section writing guidance. Scaffolded with `<!-- ANALYST: insert content here -->` placeholders to be filled from the existing skill's content.
+Shared editorial brain for both Routines: cadence and timezone (§0), research conventions, multi-clock framework, editorial style, standing analytical threads, per-section writing guidance, and flash-specific editorial guidance (§6 — material-change taxonomy, length and tone, what flashes never contain, flash note format). Scaffolded with `<!-- ANALYST: insert content here -->` placeholders to be filled from the existing skill's content.
 
 -----
 
@@ -241,4 +272,6 @@ Project description, live URL (placeholder), architecture overview, local dev in
 - `npm run validate-brief content/briefs/2026-02-28-day-001.mdx` passes.
 - GitHub Actions run completes.
 - Repo pushed.
-- README explains Vercel link, routine config, first manual run.
+- Both `routine/PROMPT_morning.md` and `routine/PROMPT_flash.md` exist and describe the 09:00 / 18:00 Asia/Taipei cadence.
+- `content/context.md` contains an `## Evening flash notes` section with the `(None yet for today.)` placeholder.
+- README explains Vercel link, **both** routine configs (morning + evening, with UTC schedules 01:00 and 10:00), and first manual runs of each.

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -9,32 +9,43 @@ export default function AboutPage() {
 
       <h2>What this is</h2>
       <p>
-        A daily intelligence brief on the 2026 US-Israeli war on Iran (Operation Epic Fury),
-        produced autonomously by a Claude Code Routine and published by 3D (
+        A twice-daily intelligence series on the 2026 US-Israeli war on Iran
+        (Operation Epic Fury), produced autonomously by two Claude Code Routines
+        and published by 3D (
         <a href="https://x.com/8gara8" target="_blank" rel="noreferrer noopener">
           @8gara8
         </a>
-        ). Each brief synthesizes that day&apos;s developments through a fixed analytical
-        framework: an escalation gauge, a key-events table, a casualty ledger, and a
-        multi-clock strategic-implications section.
+        ). Each day, a <strong>full morning brief</strong> (09:00 Asia/Taipei)
+        synthesizes developments through a fixed analytical framework — escalation
+        gauge, key events, casualty ledger, multi-clock strategic implications. An{' '}
+        <strong>evening flash</strong> (18:00 Asia/Taipei) notes any material
+        intra-day developments since the morning run; flashes are intentionally
+        lightweight, captured as short time-stamped notes on the rolling context
+        and folded into the next morning&apos;s full brief rather than published
+        as separate pages.
       </p>
 
       <h2>What this is not</h2>
       <p>
-        This is one analyst&apos;s daily synthesis, not a wire service. It is not
-        comprehensive coverage. It is not an institutional product. It is not real-time.
-        It is not affiliated with any organization, government, or news outlet. The
-        ceasefire probability figures are analytical judgments, not market-derived odds.
+        This is one analyst&apos;s synthesis, not a wire service. It is not
+        comprehensive coverage. It is not an institutional product. It is not
+        real-time. It is not affiliated with any organization, government, or
+        news outlet. The ceasefire probability figures are analytical judgments,
+        not market-derived odds. Evening flashes are time-stamped intra-day
+        notes, not breaking-news alerts.
       </p>
 
       <h2>Methodology</h2>
       <p>
-        Each brief draws from a minimum of 8 dated, web-cited sources, prioritizing Al
-        Jazeera, Reuters, AP, NPR, CBS/NBC/ABC News, Times of Israel, CENTCOM releases,
-        and Wikipedia&apos;s Timeline of the 2026 Iran war. Casualty figures use dual
-        sourcing where available (HRANA alongside official Iranian figures). Analytical
-        judgments are explicitly prefixed with &quot;Analytical judgment:&quot; and are
-        distinguished from sourced facts.
+        Each morning full brief draws from a minimum of 8 dated, web-cited sources,
+        prioritizing Al Jazeera, Reuters, AP, NPR, CBS/NBC/ABC News, Times of Israel,
+        CENTCOM releases, and Wikipedia&apos;s Timeline of the 2026 Iran war. Casualty
+        figures use dual sourcing where available (HRANA alongside official Iranian
+        figures). Each material-change evening flash draws on a minimum of 3 dated
+        sources from the same priority list; no-material-change flashes are logged
+        as terse one-to-three-sentence notes. Analytical judgments across both
+        cadences are explicitly prefixed with &quot;Analytical judgment:&quot; and
+        are distinguished from sourced facts.
       </p>
 
       <h2>Open source</h2>

--- a/content/context.md
+++ b/content/context.md
@@ -61,3 +61,7 @@ reported.
 - Any mediation offer from Oman, Qatar, Switzerland, or China, and Tehran's
   initial posture toward each.
 - Houthi activity against Red Sea shipping and any US naval response.
+
+## Evening flash notes
+
+(None yet for today.)

--- a/routine/INSTRUCTIONS.md
+++ b/routine/INSTRUCTIONS.md
@@ -6,6 +6,27 @@ substantive content of several sections below is **scaffolded**: the analyst
 `/mnt/skills/user/me-war-intel-brief/SKILL.md` after the repo is live. Until
 then, the structure and marked placeholders below define what goes where.
 
+## 0. Cadence and timezone
+
+The brief publishes **twice daily**, both cadences anchored to Asia/Taipei
+(analyst's home timezone):
+
+- **09:00 Asia/Taipei (01:00 UTC) — morning full brief.** The canonical brief
+  for the day. Full frontmatter schema, minimum 8 sources, escalation gauge,
+  events table, casualties table, multi-clock strategic implications. Driven
+  by `routine/PROMPT_morning.md`.
+- **18:00 Asia/Taipei (10:00 UTC) — evening flash.** A lightweight intra-day
+  delta capturing material developments since the morning run. Under the v2
+  light-touch scope, the flash appends a paragraph to the
+  `## Evening flash notes` section of `content/context.md` rather than writing
+  a new brief file. Driven by `routine/PROMPT_flash.md`. See §6 below for
+  editorial guidance.
+
+The morning Routine rewrites `content/context.md` in full and resets the
+`## Evening flash notes` section to `(None yet for today.)`; the evening
+Routine only touches that one section. Everything else in this document
+applies primarily to the morning Routine; flash-specific guidance is in §6.
+
 ## 1. Research conventions
 
 ### Priority sources
@@ -163,3 +184,65 @@ never put object or array literals as props on the structural components in the
   is being made.
 
 <!-- ANALYST: insert any additional per-section guidance from the existing skill -->
+
+## 6. Flash reports (evening Routine only)
+
+The 18:00 Asia/Taipei flash is a **delta, not a digest**. Under the v2
+light-touch scope, the flash writes a single time-stamped paragraph to the
+`## Evening flash notes` section of `content/context.md`. It does not create a
+new `.mdx` file, does not touch the validator's current single-brief-per-day
+model, and does not change any numbers that the morning brief already
+published.
+
+### Material-change taxonomy
+
+A flash is warranted when one or more of the following has happened in the
+~9 hours since the morning run (roughly 01:00–10:00 UTC):
+
+- New strike, attack, or military operation
+- Change in ceasefire-track status (new talks, collapsed talks, new terms)
+- Casualty figure revision > 10% for any actor
+- Named mediator entering or exiting
+- Significant market move: Brent > 3%, notable equity moves on war-sensitive
+  names, or a visible shift in Asian LNG pricing
+- Unexpected diplomatic statement from a previously-uninvolved party
+- A cluster of smaller developments that together shift tomorrow's framing
+
+If none of the above is satisfied, write a **no-material-change flash** —
+one to three terse sentences noting that posture is unchanged across the
+dimensions you checked.
+
+### Length and tone
+
+- **Material-change flash:** 3–6 sentences. Lead with the development, give
+  one-line implication, and flag whether the change argues for an update to
+  escalation direction or 30-day ceasefire probability in tomorrow's morning
+  brief. Minimum 3 dated, web-cited sources.
+- **No-material-change flash:** 1–3 sentences. No source floor (the whole
+  point is that the research window turned up nothing material).
+
+### What flashes never contain
+
+- Casualty numbers in any structured form. Describe revisions qualitatively;
+  tomorrow's morning brief captures formal figures.
+- Clock-dimension state changes. Clocks move on day-level timescales, not
+  6-hour ones.
+- A restatement of the morning brief's analysis. If you find yourself
+  rewriting the morning's Strategic Implications, stop — that's a digest,
+  not a flash.
+
+### Format
+
+Prepend each flash note with the UTC timestamp of the Routine run, bolded:
+
+> **[10:12 UTC]** Iran fires four ballistic missiles at Haifa ~17:00 Tel Aviv
+> time; initial reports indicate two intercepted and two causing property
+> damage. Iran's statement frames the strike as a response to the Red Sea
+> naval incident earlier today. Analytical judgment: this argues for escalation
+> direction to remain `escalating` in tomorrow's brief and for ceasefire
+> probability to stay pinned in the single digits. (Times of Israel,
+> Reuters, Al Jazeera — accessed 2026-04-22T09:58Z.)
+
+Replace the placeholder line `(None yet for today.)` left by the morning
+Routine with the flash note. If a previous flash already ran today (rare;
+only in manual reruns), append below that one rather than overwriting it.

--- a/routine/PROMPT_flash.md
+++ b/routine/PROMPT_flash.md
@@ -1,0 +1,80 @@
+# Daily ME War Intel Brief — Evening Flash Routine
+
+You are running the **evening flash Routine** at 18:00 Asia/Taipei (10:00 UTC).
+This is a **lightweight intra-day update**, not a re-research of the morning
+brief. The morning Routine (see `routine/PROMPT_morning.md`) already wrote
+today's canonical full brief ~9 hours ago; your job is to note material changes
+since then.
+
+**Scope note for v2 light-touch:** the repo's brief schema, validator, and
+site layout remain single-brief-per-day (v1). You therefore do **not** create a
+new MDX file — you append a single paragraph to `content/context.md`'s
+`## Evening flash notes` section. The morning Routine will read these notes
+the next day and fold them into the new day's brief. This bridge will be
+replaced by dedicated flash MDX files + a flash page treatment once that
+infrastructure is built; until then, your only writable surface is the
+flash-notes section of `content/context.md`.
+
+Today's date: use the current date when you read this. Day count: compute from
+2026-02-28 (Day 1).
+
+## Steps
+
+1. Read `routine/INSTRUCTIONS.md` — specifically the "Flash reports" section
+   for editorial guidance, plus the shared research conventions.
+2. Read today's morning full brief at `content/briefs/YYYY-MM-DD-day-NNN.mdx`
+   to establish the baseline of what's already been reported. Do not
+   re-research ground the morning brief already covered.
+3. Read `content/context.md` for operational context. Note what's already in
+   the `## Evening flash notes` section — normally this will be the placeholder
+   `(None yet for today.)` left by the morning Routine.
+4. Perform **targeted** research focused on the ~9-hour window since the
+   morning run (roughly 01:00 UTC to 10:00 UTC today). Scope:
+   - Breaking military developments (strikes, attacks, new operations)
+   - Casualty figure revisions > 10%
+   - Ceasefire-track or mediation changes
+   - Named mediator entering or exiting
+   - Significant market moves (Brent > 3%, notable equity moves on
+     war-sensitive names)
+   - Unexpected diplomatic statements from previously-uninvolved parties
+5. Determine **material-change status**:
+   - **No material change.** If nothing substantive has developed beyond what
+     the morning brief already covers, write a terse 1–3 sentence note under
+     `## Evening flash notes` in `content/context.md`, e.g.:
+     > **[HH:MM UTC]** No material change since morning brief. Iranian missile
+     > posture unchanged; Hormuz status unchanged; no new mediation signals.
+   - **Material change.** Write a 3–6 sentence paragraph under
+     `## Evening flash notes`, time-stamped with the flash-run UTC time.
+     Cover only what's new: the development, one-line implication for the
+     morning brief's framing, and whether the change argues for an update to
+     escalation direction or 30-day ceasefire probability (as guidance for
+     tomorrow's morning Routine; you do not change any numbers yourself).
+     Minimum 3 dated, web-cited sources listed inline as footnotes or at the
+     end of the paragraph.
+6. Replace the `(None yet for today.)` placeholder with your note. Leave every
+   other section of `content/context.md` untouched.
+7. Commit and push to `main`. Message:
+   - `Day NNN flash — YYYY-MM-DD` for material-change flashes, or
+   - `Day NNN flash (quiet) — YYYY-MM-DD` for no-material-change flashes.
+
+## Hard rules
+
+- **Never restate the morning brief.** A flash is a delta, not a digest.
+- **Never create a new `.mdx` file.** The repo's v1 schema/validator does not
+  yet accept flash files; your only writable surface today is the
+  `## Evening flash notes` section of `content/context.md`.
+- **Never touch any other section of `content/context.md`.** Not `Current war
+  status`, not `Cumulative state`, not `Active deadlines` — leave those to the
+  morning Routine.
+- **Never change casualty numbers or clock states in any frontmatter.**
+  Describe changes qualitatively in your flash note; tomorrow morning's Routine
+  captures formal numbers.
+- **Never touch `app/`, `components/`, `lib/`, `data/`, or anything under
+  `routine/`.** This is a content routine.
+- **No silently fabricated data.** If nothing is confirmable, write a
+  no-material-change flash instead of speculating.
+- **If today's morning brief does not exist** (morning Routine failed), you
+  are **promoted** to writing the full brief. Follow `routine/PROMPT_morning.md`
+  instead — full schema, 8-source floor, sidecar, and all — and set
+  `gap_acknowledged: true` in the brief frontmatter.
+- **No partial commits.** If you cannot produce a valid note, commit nothing.

--- a/routine/PROMPT_flash.md
+++ b/routine/PROMPT_flash.md
@@ -51,8 +51,15 @@ Today's date: use the current date when you read this. Day count: compute from
      tomorrow's morning Routine; you do not change any numbers yourself).
      Minimum 3 dated, web-cited sources listed inline as footnotes or at the
      end of the paragraph.
-6. Replace the `(None yet for today.)` placeholder with your note. Leave every
-   other section of `content/context.md` untouched.
+6. Write your note to the `## Evening flash notes` section of
+   `content/context.md`:
+   - If the section contains the `(None yet for today.)` placeholder (the
+     normal case), **replace** the placeholder with your note.
+   - If the section already contains a prior flash note from earlier today
+     (a manual rerun), **append** your note below the existing one rather
+     than overwriting it — intra-day history must be preserved for the
+     next morning's brief to incorporate.
+   Leave every other section of `content/context.md` untouched.
 7. Commit and push to `main`. Message:
    - `Day NNN flash — YYYY-MM-DD` for material-change flashes, or
    - `Day NNN flash (quiet) — YYYY-MM-DD` for no-material-change flashes.
@@ -70,11 +77,16 @@ Today's date: use the current date when you read this. Day count: compute from
   Describe changes qualitatively in your flash note; tomorrow morning's Routine
   captures formal numbers.
 - **Never touch `app/`, `components/`, `lib/`, `data/`, or anything under
-  `routine/`.** This is a content routine.
+  `routine/`.** This is a content routine. The one exception — active only
+  on the promoted-run path below — is `lib/brief-data.ts`, which must be
+  edited to register the new sidecar per `PROMPT_morning.md` step 6.
 - **No silently fabricated data.** If nothing is confirmable, write a
   no-material-change flash instead of speculating.
 - **If today's morning brief does not exist** (morning Routine failed), you
   are **promoted** to writing the full brief. Follow `routine/PROMPT_morning.md`
   instead — full schema, 8-source floor, sidecar, and all — and set
-  `gap_acknowledged: true` in the brief frontmatter.
+  `gap_acknowledged: true` in the brief frontmatter. The promoted path
+  requires creating `content/briefs/<slug>.data.ts` and registering it in
+  `lib/brief-data.ts` (the morning prompt's one `lib/` exception); do that,
+  overriding the "never touch `lib/`" rule above for this specific file.
 - **No partial commits.** If you cannot produce a valid note, commit nothing.

--- a/routine/PROMPT_flash.md
+++ b/routine/PROMPT_flash.md
@@ -66,27 +66,43 @@ Today's date: use the current date when you read this. Day count: compute from
 
 ## Hard rules
 
+The hard rules below apply to the **normal flash path**. All of them are
+overridden on the **promoted-run path** (see the final rule and the
+promoted-run section that follows it), where the absence of today's morning
+brief forces you to write a full brief instead of a flash note.
+
 - **Never restate the morning brief.** A flash is a delta, not a digest.
-- **Never create a new `.mdx` file.** The repo's v1 schema/validator does not
-  yet accept flash files; your only writable surface today is the
-  `## Evening flash notes` section of `content/context.md`.
-- **Never touch any other section of `content/context.md`.** Not `Current war
-  status`, not `Cumulative state`, not `Active deadlines` — leave those to the
-  morning Routine.
+- **Never create a new `.mdx` file.** (Normal flash path only.) The repo's v1
+  schema/validator does not yet accept flash files; on the normal flash path
+  your only writable surface is the `## Evening flash notes` section of
+  `content/context.md`. On the promoted-run path, this rule is lifted — you
+  create the full-brief `.mdx` per `PROMPT_morning.md` step 6.
+- **Never touch any other section of `content/context.md`.** (Normal flash
+  path only.) Not `Current war status`, not `Cumulative state`, not `Active
+  deadlines` — leave those to the morning Routine. On the promoted-run path,
+  you rewrite `content/context.md` in full per the morning prompt.
 - **Never change casualty numbers or clock states in any frontmatter.**
-  Describe changes qualitatively in your flash note; tomorrow morning's Routine
-  captures formal numbers.
+  (Normal flash path only.) Describe changes qualitatively in your flash
+  note; tomorrow morning's Routine captures formal numbers. On the
+  promoted-run path, you write casualty numbers and clock states as the
+  morning Routine normally would.
 - **Never touch `app/`, `components/`, `lib/`, `data/`, or anything under
   `routine/`.** This is a content routine. The one exception — active only
   on the promoted-run path below — is `lib/brief-data.ts`, which must be
   edited to register the new sidecar per `PROMPT_morning.md` step 6.
-- **No silently fabricated data.** If nothing is confirmable, write a
-  no-material-change flash instead of speculating.
+- **No silently fabricated data.** (Both paths.) If nothing is confirmable on
+  the normal flash path, write a no-material-change flash instead of
+  speculating. On the promoted-run path, flag uncertain fields per the
+  morning prompt.
 - **If today's morning brief does not exist** (morning Routine failed), you
   are **promoted** to writing the full brief. Follow `routine/PROMPT_morning.md`
-  instead — full schema, 8-source floor, sidecar, and all — and set
-  `gap_acknowledged: true` in the brief frontmatter. The promoted path
-  requires creating `content/briefs/<slug>.data.ts` and registering it in
-  `lib/brief-data.ts` (the morning prompt's one `lib/` exception); do that,
-  overriding the "never touch `lib/`" rule above for this specific file.
-- **No partial commits.** If you cannot produce a valid note, commit nothing.
+  instead — full schema, 8-source floor, sidecar, rewritten `content/context.md`,
+  and all — and set `gap_acknowledged: true` in the brief frontmatter. On the
+  promoted-run path, the "never create a new `.mdx` file," "never touch other
+  sections of `content/context.md`," "never change casualty numbers or clock
+  states," and "never touch `lib/`" rules above are all lifted to the extent
+  required by the morning prompt's steps 6 and 7.
+- **No partial commits.** (Both paths.) On the normal flash path, if you
+  cannot produce a valid note, commit nothing. On the promoted-run path, if
+  you cannot produce both the brief MDX and a correctly updated
+  `content/context.md`, commit nothing.

--- a/routine/PROMPT_morning.md
+++ b/routine/PROMPT_morning.md
@@ -1,6 +1,11 @@
-# Daily ME War Intel Brief — Run Prompt
+# Daily ME War Intel Brief — Morning Routine
 
-You are running the daily Middle East War Intelligence Brief for the public site.
+You are running the **morning full-brief Routine** at 09:00 Asia/Taipei
+(01:00 UTC). This is the canonical full brief for the day. A separate evening
+Routine runs at 18:00 Asia/Taipei (10:00 UTC) to capture any material intra-day
+developments (see `routine/PROMPT_flash.md`); you do not do intra-day updates
+yourself.
+
 Today's date: use the current date when you read this. Day count: compute from
 2026-02-28 (Day 1).
 
@@ -8,10 +13,12 @@ Today's date: use the current date when you read this. Day count: compute from
 
 1. Read `routine/INSTRUCTIONS.md` in full. These are the editorial conventions —
    research priorities, source discipline, multi-clock framework, neutrality guidance.
-2. Read `content/context.md` to load yesterday's state.
+2. Read `content/context.md` to load yesterday's state. Note any entries in its
+   `## Evening flash notes` section left by yesterday's evening Routine — these
+   are useful intra-day signals you should incorporate into today's brief.
 3. Run the **continuity check**: read the most recent brief in `content/briefs/`.
-   If its day count is not (today's day count − 1), a previous run was skipped.
-   Note the gap explicitly in today's brief Executive Summary and set
+   If its day count is not (today's day count − 1), a previous morning run was
+   skipped. Note the gap explicitly in today's brief Executive Summary and set
    `gap_acknowledged: true` in frontmatter.
 4. Review `routine/examples/` for few-shot reference material if present.
 5. Perform the research per INSTRUCTIONS.md. Minimum 8 distinct, dated, web-cited
@@ -25,6 +32,10 @@ Today's date: use the current date when you read this. Day count: compute from
    `routine/INSTRUCTIONS.md` §4.5, and register it in `lib/brief-data.ts` by
    adding one import line and one entry to `briefDataBySlug`.
 7. Rewrite `content/context.md` in full per `routine/schemas/context.schema.md`.
+   When rewriting, **reset the `## Evening flash notes` section** to the single
+   placeholder line `(None yet for today.)` — yesterday's flash notes are
+   incorporated into today's brief body (see step 2) and should not persist
+   into the new day's context.
 8. Commit and push to `main` with message: `Day NNN brief — YYYY-MM-DD`.
 
 ## Hard rules

--- a/routine/examples/README.md
+++ b/routine/examples/README.md
@@ -2,4 +2,4 @@
 
 This directory is a placeholder. The analyst will populate it during Phase 1.5 with three reference briefs (Days 40, 47, 50) drawn from the existing DOCX archive.
 
-The routine looks here for exemplars of prose density, sourcing discipline, and strategic-implications structure. Until those are added, the routine falls back to the structure rules in `routine/PROMPT.md`, `routine/INSTRUCTIONS.md`, and `SPEC.md` §2.
+Both routines look here for exemplars of prose density, sourcing discipline, and strategic-implications structure. Until the analyst populates this directory, the routines fall back to the structure rules in `routine/PROMPT_morning.md` (for the morning full-brief Routine), `routine/PROMPT_flash.md` (for the evening flash Routine), `routine/INSTRUCTIONS.md`, and `SPEC.md` §2.

--- a/routine/schemas/context.schema.md
+++ b/routine/schemas/context.schema.md
@@ -1,6 +1,6 @@
 # `content/context.md` — Structure Schema
 
-This document defines the required structure of `content/context.md`. The routine rewrites this file in full on every run. It is not append-only.
+This document defines the required structure of `content/context.md`. The **morning** Routine rewrites this file in full on every run. The **evening** flash Routine appends only to the `## Evening flash notes` section and leaves every other section untouched.
 
 ## Required front matter
 
@@ -22,6 +22,7 @@ The file must contain exactly these second-level (`##`) sections, in this order:
 4. **## Diplomatic state** — brief prose on any active or offered mediation tracks.
 5. **## Standing analytical threads** — bullet list of the durable analytical threads being tracked across briefs (Taiwan LNG, interceptor depletion, US political will, semiconductor supply chain, plus any newly surfaced threads).
 6. **## What to watch tomorrow** — 3–7 bullets of concrete signals to monitor in the next 24 hours.
+7. **## Evening flash notes** — placeholder `(None yet for today.)` when the morning Routine rewrites the file; one or more time-stamped paragraphs when the evening Routine has appended notes. Morning Routine always resets this section to the placeholder so yesterday's notes do not persist.
 
 ## Style
 


### PR DESCRIPTION
## Summary

Light-touch v1 → v1.2 update focused on the two headline changes: **timezone is now Asia/Taipei** and **the routine fires twice daily** (morning full brief + evening flash). Deliberately avoids touching the app code, schemas, validator, or components — those keep working as-is for full briefs, and flash output is bridged through `content/context.md` rather than new MDX files. The heavier build (dedicated flash schema, `FlashLayout`, nested archive, dual validator rules, two OG templates, filtered aggregates) is left for a later PR when flashes actually start landing and the bridge needs promoting.

## What changed

- **`routine/PROMPT.md` → `routine/PROMPT_morning.md`.** Same morning full-brief flow, now annotated with the 09:00 Asia/Taipei / 01:00 UTC schedule and a new step 7 instruction: when rewriting `content/context.md`, reset the `## Evening flash notes` section to `(None yet for today.)`.
- **New `routine/PROMPT_flash.md`.** Evening flash Routine at 18:00 Asia/Taipei / 10:00 UTC. Reads the morning brief and `content/context.md`, does targeted research on the ~9-hour delta, and writes one time-stamped paragraph under `## Evening flash notes` — either material-change (3–6 sentences, min 3 sources) or no-material-change (1–3 sentences, no source floor). Never writes new `.mdx` files, never touches other sections of `content/context.md`, never changes casualty numbers or clock states. If the morning brief is missing, the flash is promoted to writing a full brief per the morning prompt with `gap_acknowledged: true`.
- **`routine/INSTRUCTIONS.md`.** New §0 (cadence and timezone — both routines, Asia/Taipei anchor, which file drives which cadence) and new §6 (flash reports — material-change taxonomy, length and tone, what flashes never contain, format example).
- **`content/context.md`.** New `## Evening flash notes` section with `(None yet for today.)` placeholder at the bottom.
- **`routine/schemas/context.schema.md`.** Documents the morning-rewrites vs. evening-appends split and adds the new required section.
- **`README.md`.** Two-Producer architecture, routine setup now walks through configuring **both** routines with their UTC schedules.
- **`app/about/page.tsx`.** Twice-daily framing; distinguishes morning methodology (min 8 sources, full framework) from flash methodology (min 3 sources for material change; terse for no-material-change); flashes described as intra-day notes folded into the next morning's brief, not separate pages.
- **`SPEC.md`.** v1.2 header + changelog banner, updated "What you're building" with two Producers, §7 includes the new Evening flash notes section, §8 split into §8.1 (morning) and §8.2 (flash) mirroring the prompt files, §14 Definition of done updated.

## What deliberately did **not** change

- `routine/schemas/brief-frontmatter.schema.json` — no `report_type` field yet; not needed while flashes live in `context.md`.
- `scripts/validate-brief.ts` — no dual rule set; the evening commit only modifies `content/context.md`, which the validator already ignores.
- `scripts/build-data.ts`, `lib/data-aggregation.ts` — no flash filtering; all briefs are still full briefs.
- `lib/types.ts`, `lib/briefs.ts`, `lib/mdx-options.ts` — unchanged.
- `app/page.tsx`, `app/brief/[slug]/page.tsx`, `app/archive/page.tsx`, `app/timeline|casualties|clocks/page.tsx` — unchanged; no nested archive, no flash layout, no filtered charts.
- `app/api/og/[slug]/route.tsx` — single OG template (no flash variant).
- No new `FlashLayout` or `FlashBacklink` components.

These are all on the table for a follow-up once the analyst wants flashes to become their own pages.

## Test plan

- [ ] `npm install && npm run build` still succeeds locally.
- [ ] `npm run dev` — `/`, `/brief/2026-02-28-day-001`, `/archive`, `/timeline`, `/casualties`, `/clocks`, `/about` all render. `/about` shows the new twice-daily copy.
- [ ] `npm run validate-brief content/briefs/2026-02-28-day-001.mdx` passes (no schema changes were made).
- [ ] CI `validate-brief.yml` passes on this PR.
- [ ] Both `routine/PROMPT_morning.md` and `routine/PROMPT_flash.md` read cleanly end-to-end — schedule, steps, hard rules — from a cold read.
- [ ] `content/context.md` contains the new `## Evening flash notes` section with the placeholder.

## Next steps for the analyst

1. Merge this PR.
2. At [claude.ai/code/scheduled](https://claude.ai/code/scheduled), configure **two** Routines pointing at `main`:
   - Morning — prompt: `routine/PROMPT_morning.md`, schedule: 01:00 UTC daily.
   - Evening — prompt: `routine/PROMPT_flash.md`, schedule: 10:00 UTC daily.
3. Trigger a manual first run of each to validate the pipeline.
4. Decide whether/when to promote flashes from `context.md` notes to dedicated `.mdx` files + flash page treatment (requires the heavier Phase 2/3 work that was explicitly deferred here).