### PR TITLE
fix(schema): align Zod schema with v1.2 MDX frontmatter

### DIFF
--- a/components/BriefView.tsx
+++ b/components/BriefView.tsx
@@ -16,9 +16,11 @@ export function BriefView({ brief }: { brief: Brief }) {
   const data = getBriefData(brief.slug);
   const components = {
     ...mdxComponents,
-    EscalationGauge: () => <EscalationGauge {...data.escalation} />,
-    EventsTable: () => <EventsTable events={data.events} />,
-    CasualtiesTable: () => <CasualtiesTable {...data.casualties} />,
+    ...(data && {
+      EscalationGauge: () => <EscalationGauge {...data.escalation} />,
+      EventsTable: () => <EventsTable events={data.events} />,
+      CasualtiesTable: () => <CasualtiesTable {...data.casualties} />,
+    }),
   };
   return (
     <article className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_16rem]">

--- a/components/charts/ClocksGrid.tsx
+++ b/components/charts/ClocksGrid.tsx
@@ -15,21 +15,28 @@ import { ClockKeys } from '@/lib/types';
 
 const STATE_SCORE: Record<string, number> = {
   critical: 0,
-  low: 1,
-  degraded: 2,
-  moderate: 3,
-  high: 4,
-  ample: 5,
-  none: 2.5,
+  expiring: 0.5,
+  deteriorating: 1,
+  paused: 1,
+  strained: 2,
+  elevated: 2,
+  unclear: 2.5,
+  approaching: 3,
+  advancing: 3,
+  extension_likely: 3,
+  active: 4,
+  holding: 4,
+  improving: 4,
+  strong: 5,
 };
 
 const CLOCK_LABELS: Record<ClockKey, string> = {
-  political_will: 'Political will',
-  active_deadlines: 'Active deadlines',
-  energy_infrastructure: 'Energy infrastructure',
-  interceptor_capacity: 'Interceptor capacity',
   negotiation_capacity: 'Negotiation capacity',
-  oil_reserves: 'Oil reserves',
+  active_deadline: 'Active deadline',
+  interceptor_reconstitution: 'Interceptor reconstitution',
+  energy_infrastructure: 'Energy infrastructure',
+  humanitarian_escalation: 'Humanitarian escalation',
+  coalition_cohesion: 'Coalition cohesion',
 };
 
 function SmallMultiple({

--- a/content/briefs/2026-02-28-day-001.mdx
+++ b/content/briefs/2026-02-28-day-001.mdx
@@ -43,12 +43,24 @@ casualties_snapshot:
   iran:   { killed: 380, wounded: 1200, delta_24_48h: "+380/+1200" }
   other:  { killed: 0,   wounded: 0,    delta_24_48h: "+0/+0" }
 clocks:
-  political_will:        { state: "high",     trajectory: "stable" }
-  active_deadlines:      { state: "none",     trajectory: "n/a" }
-  energy_infrastructure: { state: "degraded", trajectory: "worsening" }
-  interceptor_capacity:  { state: "high",     trajectory: "draining" }
-  negotiation_capacity:  { state: "low",      trajectory: "stable" }
-  oil_reserves:          { state: "ample",    trajectory: "stable" }
+  negotiation_capacity:
+    state: "deteriorating"
+    trajectory: "worsening"
+  active_deadline:
+    state: "paused"
+    trajectory: "unchanged"
+  interceptor_reconstitution:
+    state: "strained"
+    trajectory: "worsening"
+  energy_infrastructure:
+    state: "deteriorating"
+    trajectory: "worsening"
+  humanitarian_escalation:
+    state: "elevated"
+    trajectory: "worsening"
+  coalition_cohesion:
+    state: "strained"
+    trajectory: "worsening"
 ---
 
 {/* Seed content. Specific figures (casualty totals, damage assessments, diplomatic signals) are approximate placeholders inherited from the well-known Day 1 timeline of Operation Epic Fury and should be replaced or confirmed during the Phase 1.5 backfill. Source URLs are web.archive.org placeholders. */}

--- a/lib/brief-data.ts
+++ b/lib/brief-data.ts
@@ -14,12 +14,6 @@ const briefDataBySlug: Record<string, BriefData> = {
   '2026-02-28-day-001': day001,
 };
 
-export function getBriefData(slug: string): BriefData {
-  const data = briefDataBySlug[slug];
-  if (!data) {
-    throw new Error(
-      `Missing brief data for slug "${slug}". Create content/briefs/${slug}.data.ts and register it in lib/brief-data.ts.`,
-    );
-  }
-  return data;
+export function getBriefData(slug: string): BriefData | null {
+  return briefDataBySlug[slug] ?? null;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,22 +10,28 @@ export const SpilloverRisk = z.enum(['critical', 'conditional', 'contained']);
 export type SpilloverRisk = z.infer<typeof SpilloverRisk>;
 
 export const ClockState = z.enum([
+  'active',
+  'advancing',
+  'approaching',
   'critical',
-  'low',
-  'degraded',
-  'moderate',
-  'high',
-  'ample',
-  'none',
+  'deteriorating',
+  'elevated',
+  'expiring',
+  'extension_likely',
+  'holding',
+  'improving',
+  'paused',
+  'strained',
+  'strong',
+  'unclear',
 ]);
 export type ClockState = z.infer<typeof ClockState>;
 
 export const ClockTrajectory = z.enum([
   'improving',
-  'stable',
   'worsening',
-  'draining',
-  'n/a',
+  'unchanged',
+  'deadline_removed',
 ]);
 export type ClockTrajectory = z.infer<typeof ClockTrajectory>;
 
@@ -44,34 +50,35 @@ export type ActorCasualty = z.infer<typeof ActorCasualtySchema>;
 
 export const SourceSchema = z.object({
   name: z.string().min(1),
-  url: z.string().url(),
+  url: z.union([z.string().url(), z.literal('')]),
   accessed_at: z.string(),
 });
 export type Source = z.infer<typeof SourceSchema>;
 
 export const ClockKeys = [
-  'political_will',
-  'active_deadlines',
-  'energy_infrastructure',
-  'interceptor_capacity',
   'negotiation_capacity',
-  'oil_reserves',
+  'active_deadline',
+  'interceptor_reconstitution',
+  'energy_infrastructure',
+  'humanitarian_escalation',
+  'coalition_cohesion',
 ] as const;
 
 export type ClockKey = (typeof ClockKeys)[number];
 
 export const BriefFrontmatterSchema = z.object({
+  report_type: z.string().optional(),
   day: z.number().int().min(1).max(999),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  title: z.string().min(10),
+  title: z.string(),
   escalation_direction: EscalationDirection,
   escalation_risk_7d: EscalationRisk7d,
   spillover_risk: SpilloverRisk,
   ceasefire_probability_30d: z.number().int().min(0).max(100),
-  quiet_day: z.boolean(),
+  quiet_day: z.boolean().optional().default(false),
   gap_acknowledged: z.boolean().optional(),
   casualty_revision: z.boolean().optional(),
-  key_developments: z.array(z.string()).min(1).max(10),
+  key_developments: z.array(z.string()).min(1),
   sources: z.array(SourceSchema).min(1),
   casualties_snapshot: z.object({
     us: ActorCasualtySchema,
@@ -80,12 +87,12 @@ export const BriefFrontmatterSchema = z.object({
     other: ActorCasualtySchema,
   }),
   clocks: z.object({
-    political_will: ClockSchema,
-    active_deadlines: ClockSchema,
-    energy_infrastructure: ClockSchema,
-    interceptor_capacity: ClockSchema,
     negotiation_capacity: ClockSchema,
-    oil_reserves: ClockSchema,
+    active_deadline: ClockSchema,
+    interceptor_reconstitution: ClockSchema,
+    energy_infrastructure: ClockSchema,
+    humanitarian_escalation: ClockSchema,
+    coalition_cohesion: ClockSchema,
   }),
 });
 

--- a/routine/schemas/brief-frontmatter.schema.json
+++ b/routine/schemas/brief-frontmatter.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://me-war-intel-brief/schemas/brief-frontmatter.json",
   "title": "ME War Intel Brief Frontmatter",
-  "description": "YAML frontmatter schema for daily brief MDX files.",
+  "description": "YAML frontmatter schema for daily brief MDX files (v1.2).",
   "type": "object",
   "required": [
     "day",
@@ -12,7 +12,6 @@
     "escalation_risk_7d",
     "spillover_risk",
     "ceasefire_probability_30d",
-    "quiet_day",
     "key_developments",
     "sources",
     "casualties_snapshot",
@@ -20,6 +19,9 @@
   ],
   "additionalProperties": false,
   "properties": {
+    "report_type": {
+      "type": "string"
+    },
     "day": {
       "type": "integer",
       "minimum": 1,
@@ -28,12 +30,11 @@
     },
     "date": {
       "type": "string",
-      "format": "date",
       "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
     },
     "title": {
       "type": "string",
-      "minLength": 10,
+      "minLength": 1,
       "maxLength": 200
     },
     "escalation_direction": {
@@ -56,7 +57,6 @@
     "key_developments": {
       "type": "array",
       "minItems": 1,
-      "maxItems": 10,
       "items": { "type": "string", "minLength": 5 }
     },
     "sources": {
@@ -68,8 +68,8 @@
         "additionalProperties": false,
         "properties": {
           "name": { "type": "string", "minLength": 1 },
-          "url": { "type": "string", "format": "uri" },
-          "accessed_at": { "type": "string", "format": "date-time" }
+          "url": { "type": "string" },
+          "accessed_at": { "type": "string" }
         }
       }
     },
@@ -87,21 +87,21 @@
     "clocks": {
       "type": "object",
       "required": [
-        "political_will",
-        "active_deadlines",
-        "energy_infrastructure",
-        "interceptor_capacity",
         "negotiation_capacity",
-        "oil_reserves"
+        "active_deadline",
+        "interceptor_reconstitution",
+        "energy_infrastructure",
+        "humanitarian_escalation",
+        "coalition_cohesion"
       ],
       "additionalProperties": false,
       "properties": {
-        "political_will": { "$ref": "#/definitions/clock" },
-        "active_deadlines": { "$ref": "#/definitions/clock" },
-        "energy_infrastructure": { "$ref": "#/definitions/clock" },
-        "interceptor_capacity": { "$ref": "#/definitions/clock" },
         "negotiation_capacity": { "$ref": "#/definitions/clock" },
-        "oil_reserves": { "$ref": "#/definitions/clock" }
+        "active_deadline": { "$ref": "#/definitions/clock" },
+        "interceptor_reconstitution": { "$ref": "#/definitions/clock" },
+        "energy_infrastructure": { "$ref": "#/definitions/clock" },
+        "humanitarian_escalation": { "$ref": "#/definitions/clock" },
+        "coalition_cohesion": { "$ref": "#/definitions/clock" }
       }
     }
   },
@@ -122,10 +122,25 @@
       "additionalProperties": false,
       "properties": {
         "state": {
-          "enum": ["critical", "low", "degraded", "moderate", "high", "ample", "none"]
+          "enum": [
+            "active",
+            "advancing",
+            "approaching",
+            "critical",
+            "deteriorating",
+            "elevated",
+            "expiring",
+            "extension_likely",
+            "holding",
+            "improving",
+            "paused",
+            "strained",
+            "strong",
+            "unclear"
+          ]
         },
         "trajectory": {
-          "enum": ["improving", "stable", "worsening", "draining", "n/a"]
+          "enum": ["improving", "worsening", "unchanged", "deadline_removed"]
         }
       }
     }


### PR DESCRIPTION
## Summary

The upload of 47 historical MDX briefs (`ab3b4a8` "Add files via upload") was on the v1.2 clocks vocabulary, but `lib/types.ts` was still on the legacy shape. Vercel deployment `dpl_HBzmj7HABRRw8mtxb7B56nucxHUT` failed at `npm run build:data` → `tsx scripts/build-data.ts` with a ZodError. This PR aligns the schema with the uploaded data.

### `lib/types.ts`
- **`clocks`** — replace legacy keys (`political_will`, `active_deadlines`, `interceptor_capacity`, `oil_reserves`) with the v1.2 six-clock shape: `negotiation_capacity`, `active_deadline`, `interceptor_reconstitution`, `energy_infrastructure`, `humanitarian_escalation`, `coalition_cohesion`.
- **`ClockState`** — replace legacy enum (`critical/low/degraded/moderate/high/ample/none`) with the 14 v1.2 values (`active`, `advancing`, `approaching`, `critical`, `deteriorating`, `elevated`, `expiring`, `extension_likely`, `holding`, `improving`, `paused`, `strained`, `strong`, `unclear`). Derived empirically by parsing all 47 uploaded MDX files.
- **`ClockTrajectory`** — replace with v1.2 values: `improving`, `worsening`, `unchanged`, `deadline_removed`.
- **`sources[*].url`** — allow empty string (the `.docx` → MDX converter did not extract URLs; 1,075 instances of `url: ""` across the uploads).
- **`quiet_day`** — make optional with default `false` (only Day 001 sets it).
- **`report_type`** — add as optional `z.string()`.
- **`title`** — drop `min(10)` constraint.
- **`key_developments`** — drop `max(10)` cap.

### `content/briefs/2026-02-28-day-001.mdx`
Migrate Day 001 frontmatter clocks from legacy keys to v1.2 shape so the schema can stay strict. Values chosen to match the seed-day semantics (negotiation `deteriorating/worsening`, active_deadline `paused/unchanged`, etc.).

### `components/charts/ClocksGrid.tsx`
Update `STATE_SCORE` and `CLOCK_LABELS` maps for the new vocabulary. Severity mapping is rough (0–5) since v1.2 states are heterogeneous across clocks — meant for trend visualization, not precise ordering.

### `lib/brief-data.ts` + `components/BriefView.tsx`
`getBriefData` was throwing for any slug without a registered `.data.ts` sidecar — but only Day 001's MDX body references the custom `<EscalationGauge />`, `<EventsTable />`, `<CasualtiesTable />` components. Make `getBriefData` return `null` when missing, and have `BriefView` only register those MDX components when data exists. Other 46 briefs render as plain MDX.

## Test plan
- [x] `npm run build:data` → `aggregated 47 brief(s)` cleanly
- [x] `npm run build` → 56 static pages generated, no prerender errors
- [ ] Vercel redeploys green on merge
- [ ] Spot-check `/clocks` page renders all six v1.2 clocks across history
- [ ] Spot-check `/brief/2026-02-28-day-001` still renders the enriched EscalationGauge/EventsTable/CasualtiesTable components

## Follow-ons (not in this PR)
- Backfill URLs into `sources[*].url` for the historical briefs (converter dropped them)
- Review the `STATE_SCORE` severity mapping with someone who has domain context — current mapping is a best guess