### PR TITLE
Address remaining Codex review comments from PR #7

### DIFF
--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -9,10 +9,10 @@ export const metadata = {
 };
 
 const RISK_SCORE: Record<string, number> = {
-  low: 1,
-  conditional: 2,
-  extreme: 3,
-  critical: 4,
+  low: 0,
+  conditional: 1,
+  extreme: 2,
+  critical: 3,
 };
 
 export default function TimelinePage() {
@@ -56,7 +56,7 @@ export default function TimelinePage() {
               title="7-day risk (ordinal)"
               rows={riskRows}
               max={4}
-              labels={['', 'low', 'cond', 'ext', 'crit']}
+              labels={['low', 'cond', 'ext', 'crit', '']}
               color={COLORS.accent}
             />
             <MiniLine

--- a/components/CasualtiesBlock.tsx
+++ b/components/CasualtiesBlock.tsx
@@ -3,14 +3,14 @@ import type { BriefFrontmatter, CasualtiesHistoryEntry } from '@/lib/types';
 import { COLORS } from '@/lib/design-tokens';
 import { Sparkbar } from './design/Sparkbar';
 
-// Parse "+142/+850" (killed/wounded) from frontmatter's delta_24_48h string.
-function parseDelta(raw: string): { dk: number; dw: number } {
-  const [kRaw, wRaw] = (raw ?? '').split('/');
-  const toNum = (s: string | undefined) => {
-    const m = (s ?? '').match(/-?\d+/);
-    return m ? parseInt(m[0], 10) : 0;
-  };
-  return { dk: toNum(kRaw), dw: toNum(wRaw) };
+// Parse strict "+k/+w" deltas (e.g. "+142/+850"). Returns nulls for
+// free-form prose (e.g. "200+ Hezbollah targets struck") so we don't
+// fabricate KIA/WIA badges from arbitrary numbers in narrative text.
+const STRICT_DELTA_RE = /^\s*\+?(\d+)\s*\/\s*\+?(\d+)\s*$/;
+function parseDelta(raw: string): { dk: number | null; dw: number | null } {
+  const m = (raw ?? '').match(STRICT_DELTA_RE);
+  if (!m) return { dk: null, dw: null };
+  return { dk: parseInt(m[1], 10), dw: parseInt(m[2], 10) };
 }
 
 type ActorKey = 'us' | 'israel' | 'iran' | 'other';
@@ -56,7 +56,7 @@ export function CasualtiesBlock({
                 style={{ letterSpacing: '-0.02em' }}
               >
                 {current.killed.toLocaleString()}
-                {dk > 0 && (
+                {dk !== null && dk > 0 && (
                   <span className="ml-1.5 font-mono text-[12px] text-accent">+{dk}</span>
                 )}
               </span>
@@ -65,7 +65,7 @@ export function CasualtiesBlock({
               </span>
               <span className="font-display text-[22px] font-medium text-paper-ink-soft tabular">
                 {current.wounded.toLocaleString()}
-                {dw > 0 && (
+                {dw !== null && dw > 0 && (
                   <span className="ml-1.5 font-mono text-[11px] text-accent-amber">
                     +{dw}
                   </span>


### PR DESCRIPTION
## Summary

PR #7 had four Codex (chatgpt-codex-connector) review comments. Two were already addressed in #7 before merge (casualty snapshot now derives deltas from frontmatter in `components/CasualtiesBlock.tsx`; masthead `totalDays` now uses `max(day)` rather than `index.length` in `components/layout/Masthead.tsx`) and are marked outdated. The two still-open threads are fixed here.

## Changes

### P1 — `components/CasualtiesBlock.tsx`: strict `+k/+w` parsing ([thread](https://github.com/8gara8/MEtracker/pull/7#discussion_r3125655596))

`parseDelta` previously pulled the first integer from any `delta_24_48h` string. Several current briefs use prose like `"200+ Hezbollah targets struck"` or `"Hezbollah rocket violation — Lebanon truce Day 7 of 10"`; the old logic would render those as `+200 KIA` or `+7 KIA` badges.

Now: match the entire string against `/^\s*\+?(\d+)\s*\/\s*\+?(\d+)\s*$/`. If it doesn't match (i.e. any prose-shaped value), return `{ dk: null, dw: null }` and the JSX suppresses the badge. `"+142/+850"` still parses correctly.

### P2 — `app/timeline/page.tsx`: risk axis normalization ([thread](https://github.com/8gara8/MEtracker/pull/7#discussion_r3125576006))

`RISK_SCORE` mapped `low→1 … critical→4` on a `max=4` axis with `labels=['', 'low', 'cond', 'ext', 'crit']`. Because `MiniLine` anchors value=0 at the bottom, every point was rendered one band above its label (`low` sat on the second-from-bottom band, not the lowest).

Now: `low→0, conditional→1, extreme→2, critical→3` with `labels=['low', 'cond', 'ext', 'crit', '']`. `low` is plotted on the lowest labeled band; the empty top band is harmless slack.

## Test plan

- [x] `npm run build` — 56 static pages, no TS/ESLint errors
- [ ] Visual QA of `/timeline` (7-day-risk mini-line shows `low` at the bottom)
- [ ] Visual QA of any brief with non-`+k/+w` `delta_24_48h` (no fake KIA/WIA badges); visual QA of Day 1 or any brief with strict `"+k/+w"` (badges still render)

https://claude.ai/code/session_01JcATQ3EccXeG9DBt4pSGHX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcATQ3EccXeG9DBt4pSGHX)_