### PR TITLE
Apply v2 final polish pass to Today view

### DIFF
--- a/components/BriefHeader.tsx
+++ b/components/BriefHeader.tsx
@@ -1,70 +1,31 @@
 import React from 'react';
 import { format, parseISO } from 'date-fns';
 import type { BriefFrontmatter } from '@/lib/types';
-import { Pill } from './design/Pill';
 
 export function BriefHeader({ frontmatter }: { frontmatter: BriefFrontmatter }) {
   const weekday = format(parseISO(frontmatter.date), 'EEE');
   return (
-    <div className="mb-5 grid grid-cols-1 items-end gap-6 md:grid-cols-[1fr_auto]">
-      <div>
-        <div className="mb-2 font-mono text-[10px] uppercase text-accent"
-          style={{ letterSpacing: '0.2em' }}
-        >
-          <span className="mr-1 text-accent">▮</span>
-          Daily Brief · Day {String(frontmatter.day).padStart(3, '0')} · {weekday}{' '}
-          {frontmatter.date}
-        </div>
-        <h1
-          className="m-0 font-display font-semibold text-paper-ink"
-          style={{
-            fontSize: 52,
-            lineHeight: 1.02,
-            letterSpacing: '-0.025em',
-            textWrap: 'balance',
-          }}
-        >
-          {frontmatter.title}
-        </h1>
+    <div>
+      <div
+        className="mb-2.5 font-mono text-[10px] uppercase text-accent"
+        style={{ letterSpacing: '0.2em' }}
+      >
+        <span className="mr-1 text-accent">▮</span>
+        Daily Brief · Day {String(frontmatter.day).padStart(3, '0')} · {weekday}{' '}
+        {frontmatter.date}
       </div>
-      <div className="min-w-[220px] md:text-right">
-        <div className="mb-1.5 font-mono text-[10px] uppercase tracking-label text-paper-ink-mute">
-          Headline indicators
-        </div>
-        <div className="flex flex-col items-start gap-1.5 md:items-end">
-          <IndicatorRow label="Direction" value={frontmatter.escalation_direction} />
-          <IndicatorRow label="7-day risk" value={frontmatter.escalation_risk_7d} />
-          <IndicatorRow label="Spillover" value={frontmatter.spillover_risk} />
-          <IndicatorRow
-            label="Ceasefire / 30d"
-            value={`${frontmatter.ceasefire_probability_30d}%`}
-            raw
-          />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function IndicatorRow({
-  label,
-  value,
-  raw,
-}: {
-  label: string;
-  value: string;
-  raw?: boolean;
-}) {
-  return (
-    <div className="flex items-center gap-2.5">
-      <span className="font-mono text-[10px] uppercase tracking-metalabel text-paper-ink-mute">
-        {label}
-      </span>
-      {raw ? (
-        <span className="font-mono text-[12px] tabular text-paper-ink">{value}</span>
-      ) : (
-        <Pill value={value} />
-      )}
+      <h1
+        className="m-0 mb-7 font-display font-semibold text-paper-ink"
+        style={{
+          fontSize: 48,
+          lineHeight: 1.05,
+          letterSpacing: '-0.025em',
+          textWrap: 'balance',
+          maxWidth: '24ch',
+        }}
+      >
+        {frontmatter.title}
+      </h1>
     </div>
   );
 }

--- a/components/BriefView.tsx
+++ b/components/BriefView.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/lib/data-aggregation';
 import { BriefHeader } from './BriefHeader';
 import { BriefFooter } from './BriefFooter';
+import { HeadlineBar } from './HeadlineBar';
 import { EscalationGauge } from './EscalationGauge';
 import { EventsTable } from './EventsTable';
 import { CasualtiesTable } from './CasualtiesTable';
@@ -37,6 +38,7 @@ export function BriefView({ brief }: { brief: Brief }) {
   return (
     <article>
       <BriefHeader frontmatter={brief.frontmatter} />
+      <HeadlineBar frontmatter={brief.frontmatter} />
 
       <SectionRule number={1} label="Multi-clock state" right="6 indicators" />
       <ClocksStrip clocks={brief.frontmatter.clocks} history={clocksHistory} />
@@ -46,20 +48,27 @@ export function BriefView({ brief }: { brief: Brief }) {
         label="Key developments"
         right={`${brief.frontmatter.key_developments.length} items`}
       />
-      <ol className="m-0 list-none p-0">
+      <ol
+        className="m-0 grid list-none grid-cols-1 gap-x-10 p-0 md:grid-cols-2"
+      >
         {brief.frontmatter.key_developments.map((h, i) => (
           <li
             key={i}
-            className="grid gap-3 border-b border-paper-rule-soft py-[10px]"
+            className="grid gap-3.5 border-b border-paper-rule-soft py-3"
             style={{ gridTemplateColumns: 'auto 1fr' }}
           >
             <span
-              className="font-mono text-[11px] text-accent"
+              className="pt-0.5 font-mono text-[11px] text-accent"
               style={{ letterSpacing: '0.08em' }}
             >
               {String(i + 1).padStart(2, '0')}
             </span>
-            <span className="font-sans text-[14px] leading-[1.45] text-paper-ink">{h}</span>
+            <span
+              className="font-sans text-[15px] leading-[1.45] text-paper-ink"
+              style={{ textWrap: 'pretty' }}
+            >
+              {h}
+            </span>
           </li>
         ))}
       </ol>
@@ -70,7 +79,14 @@ export function BriefView({ brief }: { brief: Brief }) {
       </div>
 
       <SectionRule
-        number={4}
+        number={7}
+        label="Sources"
+        right={`${brief.frontmatter.sources.length} citations`}
+      />
+      <BriefFooter frontmatter={brief.frontmatter} />
+
+      <SectionRule
+        number={8}
         label="Casualties snapshot"
         right="Cumulative · ±24–48h Δ"
       />
@@ -78,13 +94,6 @@ export function BriefView({ brief }: { brief: Brief }) {
         snapshot={brief.frontmatter.casualties_snapshot}
         history={casualtiesHistory}
       />
-
-      <SectionRule
-        number={5}
-        label="Sources"
-        right={`${brief.frontmatter.sources.length} citations`}
-      />
-      <BriefFooter frontmatter={brief.frontmatter} />
     </article>
   );
 }

--- a/components/HeadlineBar.tsx
+++ b/components/HeadlineBar.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import type { BriefFrontmatter } from '@/lib/types';
+import { COLORS, pillTone, toneColor, type Tone } from '@/lib/design-tokens';
+
+type Tile = {
+  label: string;
+  value: string;
+  tone: Tone;
+  raw?: boolean;
+};
+
+function ceasefireTone(pct: number): Tone {
+  if (pct >= 20) return 'ok';
+  if (pct >= 10) return 'mix';
+  return 'esc';
+}
+
+export function HeadlineBar({ frontmatter }: { frontmatter: BriefFrontmatter }) {
+  const tiles: Tile[] = [
+    {
+      label: 'Direction',
+      value: frontmatter.escalation_direction,
+      tone: pillTone(frontmatter.escalation_direction),
+    },
+    {
+      label: '7-day risk',
+      value: frontmatter.escalation_risk_7d,
+      tone: pillTone(frontmatter.escalation_risk_7d),
+    },
+    {
+      label: 'Spillover',
+      value: frontmatter.spillover_risk,
+      tone: pillTone(frontmatter.spillover_risk),
+    },
+    {
+      label: 'Ceasefire · 30d',
+      value: `${frontmatter.ceasefire_probability_30d}%`,
+      tone: ceasefireTone(frontmatter.ceasefire_probability_30d),
+      raw: true,
+    },
+  ];
+
+  return (
+    <div
+      className="mb-6 grid grid-cols-2 md:grid-cols-4 bg-paper-card"
+      style={{
+        border: `1px solid ${COLORS.rule}`,
+        borderLeft: `3px solid ${COLORS.accent}`,
+      }}
+    >
+      {tiles.map((t, i) => {
+        const c = toneColor(t.tone);
+        const valueColor = t.tone === 'neutral' ? COLORS.ink : c;
+        const isLast = i === tiles.length - 1;
+        return (
+          <div
+            key={t.label}
+            className="flex flex-col gap-1.5 px-[18px] py-[14px]"
+            style={{
+              borderRight: isLast ? undefined : `1px solid ${COLORS.ruleSoft}`,
+            }}
+          >
+            <div
+              className="flex items-center gap-2 font-mono text-[10px] uppercase text-paper-ink-mute"
+              style={{ letterSpacing: '0.16em' }}
+            >
+              <span
+                aria-hidden
+                className="inline-block"
+                style={{ width: 8, height: 8, background: c }}
+              />
+              {t.label}
+            </div>
+            <div
+              className="font-display font-semibold tabular"
+              style={{
+                fontSize: 28,
+                lineHeight: 1.05,
+                letterSpacing: '-0.015em',
+                color: valueColor,
+                textTransform: t.raw ? 'none' : 'uppercase',
+              }}
+            >
+              {t.value}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/layout/Masthead.tsx
+++ b/components/layout/Masthead.tsx
@@ -17,18 +17,18 @@ export function Masthead() {
 
   return (
     <div className="mb-2">
-      <div className="mb-[14px] flex items-center gap-[14px] border-b-[3px] border-double border-paper-rule pb-2">
-        <div className="font-display text-[32px] font-semibold text-paper-ink"
+      <div className="mb-[10px] flex items-baseline gap-5 border-b-[3px] border-double border-paper-rule pb-[10px]">
+        <div
+          className="flex-shrink-0 whitespace-nowrap font-display text-[26px] font-semibold text-paper-ink"
           style={{ letterSpacing: '-0.02em', lineHeight: 1 }}
         >
-          <span className="italic">ME</span> WAR — Intel Brief
+          <span className="italic">ME</span> WAR
+          <span className="font-normal text-paper-ink-mute"> · Intel Brief</span>
         </div>
-        <div className="hidden border-l border-paper-rule-soft pl-3 font-mono text-[10px] uppercase tracking-metalabel text-paper-ink-mute md:block">
-          Twice daily · Asia/Taipei 09:00 · 18:00
-          <br />
-          Autonomous research · Git-audited · 3D @8gara8
-        </div>
-        <div className="ml-auto flex items-center gap-[10px]">
+        <div className="ml-auto flex items-center gap-3">
+          <span className="hidden whitespace-nowrap font-mono text-[10px] uppercase tracking-label text-paper-ink-mute sm:inline">
+            Twice daily · 3D @8gara8
+          </span>
           <Stamp text="Unclassified · OSINT" angle={-3} />
         </div>
       </div>


### PR DESCRIPTION
## Summary

Applies the final polish pass from `design_handoff_v2_final/README.md` on top of the v2 redesign already shipped in #7.

- **Masthead**: compact single-line bar. Title dropped 32 → 26px; cadence meta (`Twice daily · 3D @8gara8`) and the `Unclassified · OSINT` stamp pinned right on the same baseline. The earlier two-line cadence block is gone.
- **BriefHeader**: full-width H1 at **48px** (down from 52), `max-width: 24ch`, `text-wrap: balance`. The vertical right-aligned indicator stack is removed — those values now live in the new HeadlineBar.
- **New `components/HeadlineBar.tsx`**: 4-cell horizontal status bar (Direction · 7-day risk · Spillover · Ceasefire 30d) between the title and the clocks strip. 28px display values, severity-tone coloring, `3px` accent left border, `1px` rule outer / `1px` rule-soft inner dividers.
- **BriefView reorder**: Casualties snapshot moved to **§08** (end of brief) per editorial preference — daily cumulative casualties are reference, not lede. Sources moved to §07. Key developments (§02) already precede the executive narrative (§03) and are now rendered as a 2-col grid at 15px leading.

## Test plan

- [x] `npm run build` — 56 static pages render cleanly
- [x] `npm run lint` — no warnings
- [ ] Preview on Vercel to verify masthead alignment, HeadlineBar tone colors across briefs, and H1 wrapping
- [ ] Spot-check a handful of archive days to confirm HeadlineBar severity tone maps correctly for `extreme`, `conditional`, `contained` values
- [ ] Confirm Casualties §08 block still renders with sparkbars on all briefs that have ≥2 days of history

Per `design_handoff_v2_final/README.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESwmjSp1geL5NoWw1AZs6d)_