### PR TITLE
Apply v2 final responsive addendum (mobile/tablet pass)

### DIFF
--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -26,46 +26,36 @@ export default function ArchivePage() {
         <p className="text-paper-ink-mute">No briefs published yet.</p>
       ) : (
         <div className="border border-paper-rule-soft">
-          <div
-            className="hidden border-b-2 border-paper-ink bg-paper-card px-[14px] py-2 font-mono text-[10px] uppercase tracking-label text-paper-ink-mute md:grid"
-            style={{
-              gridTemplateColumns:
-                '70px 100px minmax(0,1fr) 120px 120px 100px',
-            }}
-          >
-            <div>Day</div>
-            <div>Date</div>
-            <div>Title</div>
-            <div>Direction</div>
-            <div>Risk / 7d</div>
-            <div>C/F 30d</div>
+          <div className="archive-row is-header border-b-2 border-paper-ink bg-paper-card px-[14px] py-2 font-mono text-[10px] uppercase tracking-label text-paper-ink-mute">
+            <div className="col-day">Day</div>
+            <div className="col-date">Date</div>
+            <div className="col-title">Title</div>
+            <div className="col-dir">Direction</div>
+            <div className="col-risk">Risk / 7d</div>
+            <div className="col-pct">C/F 30d</div>
           </div>
           {briefs.map((b) => (
             <Link
               key={b.slug}
               href={`/brief/${b.slug}`}
-              className="block border-b border-paper-rule-soft border-l-[3px] border-l-transparent px-[14px] py-3 transition-colors hover:border-l-accent hover:bg-paper-card md:grid md:items-baseline md:gap-2"
-              style={{
-                gridTemplateColumns:
-                  '70px 100px minmax(0,1fr) 120px 120px 100px',
-              }}
+              className="archive-row border-b border-paper-rule-soft border-l-[3px] border-l-transparent px-[14px] py-3 transition-colors hover:border-l-accent hover:bg-paper-card"
             >
-              <div className="font-mono text-[13px] tabular text-accent">
+              <div className="col-day font-mono text-[13px] tabular text-accent">
                 {String(b.frontmatter.day).padStart(3, '0')}
               </div>
-              <div className="font-mono text-[12px] tabular text-paper-ink-soft">
+              <div className="col-date font-mono text-[12px] tabular text-paper-ink-soft">
                 {b.frontmatter.date}
               </div>
-              <div className="font-display text-[16px] font-medium leading-[1.3] text-paper-ink">
+              <div className="col-title font-display text-[16px] font-medium leading-[1.3] text-paper-ink">
                 {b.frontmatter.title}
               </div>
-              <div className="mt-1 md:mt-0">
+              <div className="col-dir">
                 <Pill value={b.frontmatter.escalation_direction} />
               </div>
-              <div className="mt-1 md:mt-0">
+              <div className="col-risk">
                 <Pill value={b.frontmatter.escalation_risk_7d} />
               </div>
-              <div className="mt-1 font-mono text-[13px] tabular text-paper-ink-soft md:mt-0">
+              <div className="col-pct font-mono text-[13px] tabular text-paper-ink-soft">
                 {b.frontmatter.ceasefire_probability_30d}%
               </div>
             </Link>

--- a/app/globals.css
+++ b/app/globals.css
@@ -21,6 +21,53 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+/* Brief hero H1: scales down on narrow viewports per responsive spec */
+.brief-h1 {
+  font-size: 32px;
+  line-height: 1.08;
+}
+@media (min-width: 901px) and (max-width: 1200px) {
+  .brief-h1 {
+    font-size: 42px;
+    line-height: 1.05;
+  }
+}
+@media (min-width: 1201px) {
+  .brief-h1 {
+    font-size: 48px;
+    line-height: 1.05;
+  }
+}
+
+/* Archive rows: 6-col desktop grid, 3-area collapse on narrow */
+.archive-row {
+  display: grid;
+  grid-template-columns: 70px 100px minmax(0, 1fr) 120px 120px 100px;
+  gap: 8px;
+  align-items: baseline;
+}
+.archive-row.is-header {
+  align-items: center;
+}
+@media (max-width: 900px) {
+  .archive-row {
+    grid-template-columns: 50px minmax(0, 1fr) auto;
+    grid-template-areas:
+      'day date  date'
+      'day title title'
+      'day dir   pct';
+    row-gap: 4px;
+    column-gap: 10px;
+    align-items: start;
+  }
+  .archive-row > .col-day { grid-area: day; align-self: start; }
+  .archive-row > .col-date { grid-area: date; }
+  .archive-row > .col-title { grid-area: title; }
+  .archive-row > .col-dir { grid-area: dir; align-self: center; }
+  .archive-row > .col-risk { display: none; }
+  .archive-row > .col-pct { grid-area: pct; text-align: right; align-self: center; }
+}
+
 /* Prose styling inside brief body (MDX) */
 .prose-brief {
   max-width: 72ch;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       className={`${newsreader.variable} ${plexSans.variable} ${plexMono.variable}`}
     >
       <body className="min-h-screen bg-paper-bg text-paper-ink">
-        <div className="mx-auto max-w-page px-6 py-7 md:px-11">
+        <div className="mx-auto max-w-page px-[14px] py-4 md:px-6 md:py-[22px] xl:px-11 xl:py-7">
           <Masthead />
           <main>{children}</main>
           <SiteFooter />

--- a/components/BriefHeader.tsx
+++ b/components/BriefHeader.tsx
@@ -15,10 +15,8 @@ export function BriefHeader({ frontmatter }: { frontmatter: BriefFrontmatter }) 
         {frontmatter.date}
       </div>
       <h1
-        className="m-0 mb-7 font-display font-semibold text-paper-ink"
+        className="brief-h1 m-0 mb-7 font-display font-semibold text-paper-ink"
         style={{
-          fontSize: 48,
-          lineHeight: 1.05,
           letterSpacing: '-0.025em',
           textWrap: 'balance',
           maxWidth: '24ch',

--- a/components/CasualtiesBlock.tsx
+++ b/components/CasualtiesBlock.tsx
@@ -30,7 +30,7 @@ export function CasualtiesBlock({
   history: CasualtiesHistoryEntry[];
 }) {
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
       {ACTORS.map((a) => {
         const current = snapshot[a.key];
         const { dk, dw } = parseDelta(current.delta_24_48h);

--- a/components/ClocksStrip.tsx
+++ b/components/ClocksStrip.tsx
@@ -11,7 +11,7 @@ export function ClocksStrip({
   history: ClocksHistoryEntry[];
 }) {
   return (
-    <div className="grid grid-cols-2 gap-[10px] md:grid-cols-3 lg:grid-cols-6">
+    <div className="grid grid-cols-2 gap-[10px] sm:grid-cols-3 xl:grid-cols-6">
       {CLOCK_ORDER.map((k) => {
         const clock = clocks[k];
         const spark = history.map((h) => clockScore(h.clocks[k].state));

--- a/components/EventsTable.tsx
+++ b/components/EventsTable.tsx
@@ -21,8 +21,8 @@ export type EventsTableProps = {
 export function EventsTable({ events }: EventsTableProps) {
   return (
     <div>
-      <div className="hidden border border-paper-rule-soft bg-paper-card md:block">
-        <table className="w-full border-collapse font-sans text-[13px]">
+      <div className="hidden overflow-x-auto border border-paper-rule-soft bg-paper-card md:block">
+        <table className="w-full min-w-[900px] border-collapse font-sans text-[13px]">
           <thead>
             <tr className="border-b-2 border-paper-ink font-mono text-[10px] uppercase tracking-label text-paper-ink-mute">
               <th className="w-9 px-[10px] py-2 text-left font-normal">#</th>

--- a/components/charts/ClocksGrid.tsx
+++ b/components/charts/ClocksGrid.tsx
@@ -11,7 +11,7 @@ export function ClocksGrid({
   history: ClocksHistoryEntry[];
 }) {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 min-[901px]:grid-cols-3">
       {CLOCK_ORDER.map((k) => {
         const clock = clocks[k];
         const spark = history.map((h) => clockScore(h.clocks[k].state));

--- a/components/layout/Masthead.tsx
+++ b/components/layout/Masthead.tsx
@@ -17,16 +17,16 @@ export function Masthead() {
 
   return (
     <div className="mb-2">
-      <div className="mb-[10px] flex items-baseline gap-5 border-b-[3px] border-double border-paper-rule pb-[10px]">
+      <div className="mb-[10px] flex flex-wrap items-center gap-x-5 gap-y-2 border-b-[3px] border-double border-paper-rule pb-[10px] md:items-baseline">
         <div
-          className="flex-shrink-0 whitespace-nowrap font-display text-[26px] font-semibold text-paper-ink"
+          className="flex-1 whitespace-nowrap font-display text-[22px] font-semibold text-paper-ink md:flex-none md:text-[26px]"
           style={{ letterSpacing: '-0.02em', lineHeight: 1 }}
         >
           <span className="italic">ME</span> WAR
           <span className="font-normal text-paper-ink-mute"> · Intel Brief</span>
         </div>
-        <div className="ml-auto flex items-center gap-3">
-          <span className="hidden whitespace-nowrap font-mono text-[10px] uppercase tracking-label text-paper-ink-mute sm:inline">
+        <div className="flex items-center gap-3 md:ml-auto">
+          <span className="hidden whitespace-nowrap font-mono text-[10px] uppercase tracking-label text-paper-ink-mute md:inline">
             Twice daily · 3D @8gara8
           </span>
           <Stamp text="Unclassified · OSINT" angle={-3} />

--- a/components/layout/MastheadNav.tsx
+++ b/components/layout/MastheadNav.tsx
@@ -24,14 +24,14 @@ export function MastheadNav({
 }) {
   const pathname = usePathname() ?? '/';
   return (
-    <div className="flex flex-wrap items-center border-b border-paper-rule-soft font-sans text-[12px] font-semibold uppercase tracking-stamp">
+    <div className="flex items-center overflow-x-auto border-b border-paper-rule-soft font-sans text-[11px] font-semibold uppercase tracking-stamp [scrollbar-width:none] min-[901px]:overflow-visible min-[901px]:text-[12px] [&::-webkit-scrollbar]:hidden">
       {TABS.map((t) => {
         const active = t.match(pathname);
         return (
           <Link
             key={t.href}
             href={t.href}
-            className="border-r border-paper-rule-soft px-4 py-[10px]"
+            className="whitespace-nowrap border-r border-paper-rule-soft px-3 py-[10px] min-[901px]:px-4"
             style={{
               background: active ? '#14161A' : 'transparent',
               color: active ? '#F3EEE3' : '#14161A',
@@ -41,7 +41,7 @@ export function MastheadNav({
           </Link>
         );
       })}
-      <div className="ml-auto flex items-baseline gap-[10px] px-2 py-[8px] font-mono text-[11px] tabular text-paper-ink-mute">
+      <div className="ml-auto hidden items-baseline gap-[10px] whitespace-nowrap px-2 py-[8px] font-mono text-[11px] tabular text-paper-ink-mute min-[901px]:flex">
         <span className="text-paper-ink">{date}</span>
         <span>·</span>
         <span>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,13 @@ const config: Config = {
     './content/**/*.{mdx,md}',
   ],
   theme: {
+    screens: {
+      sm: '520px',
+      md: '720px',
+      lg: '1024px',
+      xl: '1100px',
+      '2xl': '1440px',
+    },
     extend: {
       colors: {
         paper: {
@@ -43,7 +50,7 @@ const config: Config = {
         stamp: '0.16em',
       },
       maxWidth: {
-        page: '1280px',
+        page: '1440px',
         prose: '72ch',
       },
       borderRadius: {


### PR DESCRIPTION
## Summary

Implements the responsive rules from `design_handoff_v2_final/RESPONSIVE_ADDENDUM.md`, layered on top of the v2 desktop polish that landed in #9. The main README spec was already covered by the prior polish pass (commit `2d6dcc4`); this PR adds the mobile/tablet behaviour the addendum specifies and bumps the desktop max-width.

## Changes

- **Tailwind config**: custom screens (`sm:520 / md:720 / lg:1024 / xl:1100 / 2xl:1440`) and `max-w-page` bumped from 1280px to 1440px (comfortable density).
- **Page gutters**: 16/14 ≤720, 22/24 721–1024, 28/44 ≥1101 — applied via responsive padding utilities on the layout shell.
- **Masthead**: title scales 22px → 26px at md, cadence meta hides on mobile, stamp wraps below the title.
- **Sub-nav**: horizontal-scroll container (with hidden scrollbar) and reduced tab padding/font on ≤900; dateline + DAY counter hidden on ≤900.
- **Brief H1**: 32 / 42 / 48 px responsive ladder via a `.brief-h1` utility.
- **6-clock strip** (Today §01): `2 / 3 / 6` cols across 520 / 1100 thresholds.
- **Clocks dashboard** (`/clocks` §01): `1 / 2 / 3` cols across 520 / 901 thresholds.
- **Casualties snapshot** (Today §08): `2 / 4` cols across 720.
- **Archive rows**: 6-col desktop grid; collapses to a 3-area `day / date / title / dir / pct` layout at ≤900 with the Risk column hidden (per addendum). New `.archive-row` utility class encodes the `grid-template-areas` since Tailwind can't express named areas inline.
- **Events table**: kept the existing card-collapse for ≤md; on the desktop branch the table is now wrapped in `overflow-x-auto` with `min-w-[900px]` so 7 columns scroll horizontally inside the card on tablet midsize widths instead of bleeding off the page.

## Test plan

- [ ] `npm run build` passes (verified locally — all 57 static pages generate, including 48 brief routes).
- [ ] All routes `/`, `/archive`, `/timeline`, `/casualties`, `/clocks`, `/about` return 200 under `npm run dev`.
- [ ] At 375px viewport: no horizontal page overflow, masthead title fits on one line, nav tabs swipe horizontally, archive rows show as 3-area layout.
- [ ] At 1600px viewport: content fills up to 1440px, not capped at 1280.
- [ ] HeadlineBar still renders 4 cells at md+ and 2 cells below.

https://claude.ai/code/session_01BSHTY8xuyUpuREzMDnK2AS

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSHTY8xuyUpuREzMDnK2AS)_