### PR TITLE
fix(headline): prevent value overflow on mobile

### DIFF
--- a/components/HeadlineBar.tsx
+++ b/components/HeadlineBar.tsx
@@ -55,7 +55,7 @@ export function HeadlineBar({ frontmatter }: { frontmatter: BriefFrontmatter }) 
         return (
           <div
             key={t.label}
-            className="flex flex-col gap-1.5 px-[18px] py-[14px]"
+            className="flex min-w-0 flex-col gap-1.5 px-[18px] py-[14px]"
             style={{
               borderRight: isLast ? undefined : `1px solid ${COLORS.ruleSoft}`,
             }}
@@ -66,15 +66,15 @@ export function HeadlineBar({ frontmatter }: { frontmatter: BriefFrontmatter }) 
             >
               <span
                 aria-hidden
-                className="inline-block"
+                className="inline-block shrink-0"
                 style={{ width: 8, height: 8, background: c }}
               />
-              {t.label}
+              <span className="truncate">{t.label}</span>
             </div>
             <div
-              className="font-display font-semibold tabular"
+              className="font-display font-semibold tabular break-words"
               style={{
-                fontSize: 28,
+                fontSize: 'clamp(18px, 5.2vw, 28px)',
                 lineHeight: 1.05,
                 letterSpacing: '-0.015em',
                 color: valueColor,


### PR DESCRIPTION
## Summary
- The headline bar value font in `components/HeadlineBar.tsx` was hardcoded to 28px, so on mobile (where the grid collapses from 4 to 2 columns) long values like `CONDITIONAL` overflowed their cells and crossed into adjacent tiles.
- Replaced the fixed font size with `clamp(18px, 5.2vw, 28px)` so the value scales down on narrow viewports while keeping the original size on desktop.
- Added `min-w-0` on the cell, `break-words` on the value, and `truncate`/`shrink-0` on the label so flex/grid children can shrink instead of overflowing.

## Test plan
- [ ] Open `/today` on a narrow mobile viewport (≤375px) and verify `MIXED`, `CONDITIONAL`, `CONDITIONAL`, and `32%` all stay inside their tile borders
- [ ] Verify desktop layout (≥720px) is visually unchanged — values render at 28px
- [ ] Spot-check that the colored swatch + label row still fits without wrapping awkwardly

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pt2H67vDbKsceYjfGJJLDz)_