### PR TITLE
Disable daily brief-watchdog cron

### DIFF
--- a/.github/workflows/brief-watchdog.yml
+++ b/.github/workflows/brief-watchdog.yml
@@ -11,8 +11,13 @@ name: Brief watchdog
 # opens / updates an issue if no commit has landed on main since 01:00 UTC.
 
 on:
-  schedule:
-    - cron: '30 2 * * *'
+  # Daily cron disabled: the morning brief Routine moved off Claude Code
+  # scheduled sessions to a local Cowork Schedule task on the Mac (per v1.8),
+  # which direct-pushes to `main` without a `claude/...` branch + PR. The
+  # commit-since-01:00-UTC heuristic this watchdog used no longer matches the
+  # process and was firing false-positive "morning update not done" alerts.
+  # Left as workflow_dispatch only so it can still be triggered manually if
+  # the watchdog logic is ever updated for the new flow.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Removes the daily `cron` from `.github/workflows/brief-watchdog.yml` so it stops firing false-positive "morning update not done" alerts (e.g. issues #27, #28).
- The watchdog assumed the morning Routine landed via a `claude/...` branch + auto-merged PR after 01:00 UTC. With v1.8, the brief now runs from a local Cowork Schedule task on the Mac and direct-pushes to `main`, so the commit-window heuristic no longer matches reality.
- Keeps `workflow_dispatch` so the workflow can still be invoked manually if/when the watchdog logic is updated for the new flow.

## Test plan
- [ ] Confirm the `Brief watchdog` workflow no longer appears on the scheduled-runs list in the Actions tab.
- [ ] Confirm `workflow_dispatch` still works (manual run from the Actions UI).
- [ ] Close existing false-positive issues #27 and #28.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QSHCSeSDkPaz8s9wH2Vhj4)_