### PR TITLE
feat(clocks): add trailing-15-day ceasefire probability chart

### DIFF
--- a/ME_DESIGN_v1.8.md
+++ b/ME_DESIGN_v1.8.md
@@ -56,6 +56,7 @@ The doc has iterated through eight versions. Each version is preserved as its ow
 | v1.6 | Restored full source-diversity discipline. Added 12-category sourcing rubric, hard rule of minimum 6 categories per brief, explicit guidance on adversarial/state media, validator enforcement. The v1.2–v1.5 drafts had silently narrowed to 12 Western outlets — v1.6 fixes this regression in three places (§3.1 rubric, §3.5.7 lesson, validator). |
 | v1.7 | Folded in patterns from a sibling Evangent design doc: added this changelog, explicit scope boundaries (§11), success metrics (§12), and split risks from open questions (§10 → §10.1 + §10.2). No changes to architecture, rubric, or validation logic. |
 | v1.8 | **Migration of execution substrate from Anthropic-managed Claude Routines to a locally-running Cowork Schedule task on the user's persistently-on Mac.** Driven by recurring API timeout failures of the morning Routine. Replaces PR + GitHub Action + auto-merge with direct `gh` CLI push to `main` and an in-process local validator. Morning shifts 06:00 → 08:00 Taipei. Evening flash run formalised at 21:00 Taipei (was implicit in production). Folds in lessons from PR #22 (Day 059 validator failure): adds §3.5.12 mandatory `web.archive.org` URL wrapping, adds §3.5.13 pre-emit word-count guardrails, reconciles §3.5.4 length caps to actual production validator thresholds (Exec 150–300, Implications 400–800, body+sidecar 1200–4000), adds Appendix C.8 `normalize-sources.ts` helper. Corrects validator script path to `scripts/validate-brief.ts` (production) from the v1.7 doc's stale `scripts/validation/validate.js`. All §3 framework, §4 site design, §5 data model, §11 scope, §12 metrics preserved otherwise. Adds Appendix D — Cowork Schedule task definitions and `gh` CLI bootstrap. |
+| v1.9 | Added trailing-15-day ceasefire probability chart as new §01 on the Clocks tab (data already aggregated; no schema change). Documented previously undocumented routes (`/clocks`, `/casualties`, `/timeline`, `/about`, `/api`) and corrected the brief route name from `/briefs/[slug]` to `/brief/[slug]`. Repo name corrected throughout: `8gara8/MEtracker` (not `me-war-intel-brief`). |
 
 ---
 
@@ -513,6 +514,11 @@ These briefs (converted to MD from their existing DOCX archive) serve as the voi
 The website has one job: **let a person understand the current state of the war in under three seconds on a phone.**
 
 ### 4.1 Information Hierarchy
+
+**The Clocks tab (`/clocks`)** renders three sections in order:
+1. Trailing-15-day ceasefire probability chart (§01, added v1.9)
+2. Multi-clock dashboard — six dials, current state (§02)
+3. State history heatmap — one row per clock × N days (§03)
 
 **Above the fold (no scrolling on mobile):**
 - Date + Day number (e.g., "Day 52 — April 20, 2026")

--- a/SPEC.md
+++ b/SPEC.md
@@ -84,12 +84,19 @@
 ├── app/                              # Next.js App Router
 │   ├── page.tsx
 │   ├── archive/page.tsx
-│   └── briefs/[slug]/page.tsx
+│   ├── brief/[slug]/page.tsx
+│   ├── clocks/page.tsx
+│   ├── casualties/page.tsx
+│   ├── timeline/page.tsx
+│   ├── about/page.tsx
+│   └── api/...
 ├── components/
 │   ├── EscalationGauge.tsx
 │   ├── EventsTable.tsx
 │   ├── CasualtiesTable.tsx
-│   └── StatusBar.tsx
+│   ├── StatusBar.tsx
+│   └── charts/
+│       └── CeasefireProbabilityTrail.tsx
 ├── DESIGN_v1.8.md                    # Latest design doc (also lives at ~/Documents/MEwar/)
 ├── DESIGN_v1.7.md                    # Preserved for posterity
 ├── SPEC.md                           # This file (also lives at ~/Documents/MEwar/)

--- a/app/clocks/page.tsx
+++ b/app/clocks/page.tsx
@@ -1,7 +1,12 @@
 import { getLatestBrief } from '@/lib/briefs';
-import { loadClocksHistory } from '@/lib/data-aggregation';
+import {
+  loadClocksHistory,
+  loadEscalationHistory,
+  loadIndex,
+} from '@/lib/data-aggregation';
 import { ClocksGrid } from '@/components/charts/ClocksGrid';
 import { ClocksHeatmap } from '@/components/ClocksHeatmap';
+import { CeasefireProbabilityTrail } from '@/components/charts/CeasefireProbabilityTrail';
 import { SectionRule } from '@/components/design/SectionRule';
 
 export const metadata = {
@@ -10,12 +15,31 @@ export const metadata = {
 
 export default function ClocksPage() {
   const data = loadClocksHistory();
+  const escalation = loadEscalationHistory();
+  const slugByDay: Record<number, string> = Object.fromEntries(
+    loadIndex().map((b) => [b.day, b.slug]),
+  );
   const latest = getLatestBrief();
 
   return (
     <div>
       <SectionRule
         number={1}
+        label="Ceasefire probability — trailing 15 days"
+        right={latest ? `Day ${latest.frontmatter.day}` : undefined}
+      />
+      <p className="mb-[14px] max-w-[680px] font-sans text-[13px] leading-[1.55] text-paper-ink-soft">
+        30-day ceasefire-stability estimate, one point per published brief over
+        the last 15 days. Tap a dot to open that day&apos;s brief.
+      </p>
+      {escalation.length === 0 ? (
+        <p className="text-paper-ink-mute">No briefs published yet.</p>
+      ) : (
+        <CeasefireProbabilityTrail data={escalation} slugByDay={slugByDay} />
+      )}
+
+      <SectionRule
+        number={2}
         label="Multi-clock dashboard"
         right={latest ? `Day ${latest.frontmatter.day} state` : undefined}
       />
@@ -30,7 +54,7 @@ export default function ClocksPage() {
         <>
           <ClocksGrid clocks={latest.frontmatter.clocks} history={data} />
           <SectionRule
-            number={2}
+            number={3}
             label="State history (heatmap)"
             right={`${data.length} days`}
           />

--- a/components/charts/CeasefireProbabilityTrail.tsx
+++ b/components/charts/CeasefireProbabilityTrail.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import type { EscalationHistoryEntry } from '@/lib/types';
+import { COLORS } from '@/lib/design-tokens';
+
+const WINDOW_DAYS = 15;
+
+function dotColor(pct: number): string {
+  if (pct >= 60) return COLORS.accentGreen;
+  if (pct >= 30) return COLORS.accentAmber;
+  return COLORS.accent;
+}
+
+export function CeasefireProbabilityTrail({
+  data,
+  slugByDay,
+}: {
+  data: EscalationHistoryEntry[];
+  slugByDay: Record<number, string>;
+}) {
+  const router = useRouter();
+  const trail = data.slice(-WINDOW_DAYS);
+
+  if (trail.length === 0) {
+    return (
+      <div className="border border-paper-rule-soft bg-paper-card p-[14px]">
+        <p className="font-mono text-[11px] text-paper-ink-mute">
+          No briefs published yet.
+        </p>
+      </div>
+    );
+  }
+
+  const W = 1000;
+  const H = 220;
+  const pad = { l: 50, r: 24, t: 30, b: 40 };
+  const iw = W - pad.l - pad.r;
+  const ih = H - pad.t - pad.b;
+  const xs = (i: number) => pad.l + (i / Math.max(1, trail.length - 1)) * iw;
+  const ys = (pct: number) => pad.t + ih - (pct / 100) * ih;
+
+  const points = trail.map((b, i) => ({
+    x: xs(i),
+    y: ys(b.ceasefire_probability_30d),
+    b,
+  }));
+
+  const latest = trail[trail.length - 1];
+
+  return (
+    <div className="border border-paper-rule-soft bg-paper-card p-[14px]">
+      <svg viewBox={`0 0 ${W} ${H}`} width="100%" className="block">
+        {[0, 25, 50, 75, 100].map((t) => (
+          <line
+            key={t}
+            x1={pad.l}
+            x2={W - pad.r}
+            y1={ys(t)}
+            y2={ys(t)}
+            stroke={COLORS.ruleSoft}
+            strokeDasharray="2 3"
+          />
+        ))}
+        {[0, 25, 50, 75, 100].map((t) => (
+          <text
+            key={t}
+            x={pad.l - 8}
+            y={ys(t) + 3}
+            textAnchor="end"
+            fontFamily="var(--font-plex-mono)"
+            fontSize="10"
+            fill={COLORS.inkMute}
+          >
+            {t}
+          </text>
+        ))}
+        <path
+          d={points
+            .map(
+              (p, i) =>
+                `${i === 0 ? 'M' : 'L'} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`,
+            )
+            .join(' ')}
+          stroke={COLORS.ink}
+          strokeWidth={1.5}
+          fill="none"
+        />
+        {points.map((p, i) => {
+          const slug = slugByDay[p.b.day];
+          return (
+            <g
+              key={i}
+              className={slug ? 'cursor-pointer' : ''}
+              onClick={() => {
+                if (slug) router.push(`/brief/${slug}`);
+              }}
+            >
+              <title>{`Day ${p.b.day} · ${p.b.date} · ${p.b.ceasefire_probability_30d}%`}</title>
+              <circle
+                cx={p.x}
+                cy={p.y}
+                r={5}
+                fill={dotColor(p.b.ceasefire_probability_30d)}
+                stroke={COLORS.ink}
+                strokeWidth={1}
+              />
+              <text
+                x={p.x}
+                y={H - pad.b + 16}
+                textAnchor="middle"
+                fontFamily="var(--font-plex-mono)"
+                fontSize="10"
+                fill={COLORS.inkMute}
+              >
+                D{String(p.b.day).padStart(2, '0')}
+              </text>
+            </g>
+          );
+        })}
+        <text
+          x={W - pad.r}
+          y={pad.t + 6}
+          textAnchor="end"
+          fontFamily="var(--font-newsreader)"
+          fontSize="36"
+          fill={COLORS.ink}
+        >
+          {latest.ceasefire_probability_30d}%
+        </text>
+        <text
+          x={W - pad.r}
+          y={pad.t + 22}
+          textAnchor="end"
+          fontFamily="var(--font-plex-mono)"
+          fontSize="10"
+          fill={COLORS.inkMute}
+        >
+          DAY {latest.day} · 30-DAY HORIZON
+        </text>
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- New `CeasefireProbabilityTrail` SVG component (mirrors `EscalationTimeline` pattern: pure inline SVG, `COLORS` tokens, click → `/brief/[slug]`).
- Inserted as **§01** at the top of `/clocks`. Multi-clock dashboard becomes §02; state-history heatmap becomes §03.
- Reuses existing `loadEscalationHistory()` + `loadIndex()` — no schema or aggregator changes.
- Updated `SPEC.md` and `ME_DESIGN_v1.8.md` to reflect the actual repo layout (real route names, full route list); these had drifted from the codebase.

## Visual spec

- 1000×220 SVG, same padding/wrapper as `EscalationTimeline`.
- Y axis 0–100 with dashed gridlines at 0/25/50/75/100.
- Dot color: green ≥60, amber 30–59, red ≤29.
- Big serif "today" number (`var(--font-newsreader)`, 36px) in the upper-right, `DAY N · 30-DAY HORIZON` underneath.
  - Note: spec called for `--font-fraunces` with a fallback to whatever serif token is defined; this repo's serif is `--font-newsreader`, so I went straight to that per the spec's fallback instruction.
- Native `<title>` tooltip on each dot (`Day N · YYYY-MM-DD · N%`).

## Verified

- `npx tsc --noEmit` — clean
- `npm run lint` — no warnings or errors
- `npm run build` — 66 static pages, 57 briefs aggregated, `/clocks` route 1.27 kB
- Day 64 frontmatter `ceasefire_probability_30d: 19` → upper-right reads `19%`

## Test plan

- [ ] Open `/clocks` locally — §01 reads "CEASEFIRE PROBABILITY — TRAILING 15 DAYS · DAY 64"
- [ ] Big "19%" rendered in serif at upper-right
- [ ] 15 dots rendered with day labels D50…D64
- [ ] Hover any dot — native tooltip shows `Day X · YYYY-MM-DD · N%`
- [ ] Click any dot → routes to `/brief/<slug>`
- [ ] §02 = Multi-clock dashboard, §03 = State history (heatmap), both unchanged
- [ ] Resize to 390px — chart scales without overflow
- [ ] Vercel preview deploy renders correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjbQN5Sesv7in6c8ZxdNBW)_